### PR TITLE
fix: Use proper URL for thanos-replicate dashboard

### DIFF
--- a/modules/aws/kube-prometheus.tf
+++ b/modules/aws/kube-prometheus.tf
@@ -240,7 +240,7 @@ grafana:
       thanos-rule:
         url: https://raw.githubusercontent.com/thanos-io/thanos/master/examples/dashboards/rule.json
       thanos-replicate:
-        url: https://raw.githubusercontent.com/thanos-io/thanos/master/examples/dashboards/bucket-replicate.json
+        url: https://raw.githubusercontent.com/thanos-io/thanos/master/examples/dashboards/bucket_replicate.json
 VALUES
 
   thanos_store_config_default = <<VALUES


### PR DESCRIPTION
# Use proper URL for thanos-replicate dashboard

## Description

In `modules/aws/kube-prometheus.tf`, the Grafana's Thanos-replicate dashboard contains a typo.

Closes #65 

### Checklist

- [x] CI tests are passing
- [x] ~~README.md has been updated after any changes to variables and outputs. See https://github.com/particuleio/terraform-kubernetes-addons/#doc-generation~~ does not qualify
