### PR TITLE
fix: promtail volume override

### DIFF
--- a/modules/aws/loki-stack.tf
+++ b/modules/aws/loki-stack.tf
@@ -82,11 +82,23 @@ locals {
       - -client.external-labels=cluster=${var.cluster-name}
     serviceMonitor:
       enabled: ${local.kube-prometheus-stack["enabled"]}
-    extraVolumes:
+    defaultVolumes:
+      - name: containers
+        hostPath:
+          path: /var/lib/docker/containers
+      - name: pods
+        hostPath:
+          path: /var/log/pods
       - name: tls
         secret:
           secretName: ${local.promtail["name"]}-tls
-    extraVolumeMounts:
+    defaultVolumeMounts:
+      - name: containers
+        mountPath: /var/lib/docker/containers
+        readOnly: true
+      - name: pods
+        mountPath: /var/log/pods
+        readOnly: true
       - name: tls
         mountPath: /tls
         readOnly: true


### PR DESCRIPTION
# Fix promtail volume override

## Description

[Extra volumes](https://github.com/grafana/helm-charts/blob/main/charts/promtail/values.yaml#L140) in promtail chart are lists so they cannot be merged when merging user values and our [own values](https://github.com/particuleio/terraform-kubernetes-addons/blob/v1.28.1/modules/aws/loki-stack.tf#L89)

This breaks TLS if a user adds a new `extraVolume` without adding the TLS one (and the user shouldn't have to). The solution is to use the `defaultVolume` included in the chart.

With this we can have our custom config and let user override without issue

### Checklist

- [X] CI tests are passing
- [X] README.md has been updated after any changes to variables and outputs. See https://github.com/particuleio/terraform-kubernetes-addons/#doc-generation
