### PR TITLE
feat: add CRD handling for Kong and Prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ No modules.
 | [github_repository.main](https://registry.terraform.io/providers/integrations/github/latest/docs/data-sources/repository) | data source |
 | [http_http.kong_crds](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
 | [http_http.prometheus-operator_crds](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
+| [http_http.prometheus-operator_version](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
 | [kubectl_file_documents.apply](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/data-sources/file_documents) | data source |
 | [kubectl_file_documents.kong_crds](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/data-sources/file_documents) | data source |
 | [kubectl_file_documents.sync](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/data-sources/file_documents) | data source |

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ here](https://github.com/particuleio/terraform-kubernetes-addons/blob/master/.gi
 | <a name="provider_flux"></a> [flux](#provider\_flux) | ~> 0.1 |
 | <a name="provider_github"></a> [github](#provider\_github) | ~> 4.5 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | ~> 2.0 |
+| <a name="provider_http"></a> [http](#provider\_http) | n/a |
 | <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | ~> 1.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | ~> 2.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
@@ -138,6 +139,8 @@ No modules.
 | [kubectl_manifest.apply](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
 | [kubectl_manifest.cert-manager_cluster_issuers](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
 | [kubectl_manifest.cert-manager_csi_driver](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
+| [kubectl_manifest.kong_crds](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
+| [kubectl_manifest.prometheus-operator_crds](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
 | [kubectl_manifest.sync](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
 | [kubernetes_namespace.admiralty](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 | [kubernetes_namespace.cert-manager](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
@@ -225,7 +228,10 @@ No modules.
 | [flux_install.main](https://registry.terraform.io/providers/fluxcd/flux/latest/docs/data-sources/install) | data source |
 | [flux_sync.main](https://registry.terraform.io/providers/fluxcd/flux/latest/docs/data-sources/sync) | data source |
 | [github_repository.main](https://registry.terraform.io/providers/integrations/github/latest/docs/data-sources/repository) | data source |
+| [http_http.kong_crds](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
+| [http_http.prometheus-operator_crds](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
 | [kubectl_file_documents.apply](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/data-sources/file_documents) | data source |
+| [kubectl_file_documents.kong_crds](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/data-sources/file_documents) | data source |
 | [kubectl_file_documents.sync](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/data-sources/file_documents) | data source |
 | [kubectl_path_documents.cert-manager_cluster_issuers](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/data-sources/path_documents) | data source |
 | [kubectl_path_documents.cert-manager_csi_driver](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/data-sources/path_documents) | data source |

--- a/kong-crds.tf
+++ b/kong-crds.tf
@@ -1,0 +1,27 @@
+locals {
+
+  kong_crd_version = "kong-${local.kong.chart_version}"
+
+  kong_crds = "https://raw.githubusercontent.com/Kong/charts/${local.kong_crd_version}/charts/kong/crds/custom-resource-definitions.yaml"
+
+  kong_crds_apply = local.kong.manage_crds ? [for v in data.kubectl_file_documents.kong_crds.0.documents : {
+    data : yamldecode(v)
+    content : v
+    }
+  ] : null
+}
+
+data "http" "kong_crds" {
+  count = local.kong.manage_crds ? 1 : 0
+  url   = local.kong_crds
+}
+
+data "kubectl_file_documents" "kong_crds" {
+  count   = local.kong.manage_crds ? 1 : 0
+  content = data.http.kong_crds[0].body
+}
+
+resource "kubectl_manifest" "kong_crds" {
+  for_each  = local.kong.manage_crds ? { for v in local.kong_crds_apply : lower(join("/", compact([v.data.apiVersion, v.data.kind, lookup(v.data.metadata, "namespace", ""), v.data.metadata.name]))) => v.content } : {}
+  yaml_body = each.value
+}

--- a/kong.tf
+++ b/kong.tf
@@ -11,6 +11,7 @@ locals {
       enabled                = false
       default_network_policy = true
       ingress_cidrs          = ["0.0.0.0/0"]
+      manage_crds            = true
     },
     var.kong
   )

--- a/kube-prometheus-crd.tf
+++ b/kube-prometheus-crd.tf
@@ -1,0 +1,33 @@
+locals {
+
+  prometheus-operator_crd_version = local.kube-prometheus-stack.manage_crds ? yamldecode(data.http.prometheus-operator_version.0.body).appVersion : ""
+
+  prometheus-operator_crds = [
+    "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v${local.prometheus-operator_crd_version}/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml",
+    "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v${local.prometheus-operator_crd_version}/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml",
+    "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v${local.prometheus-operator_crd_version}/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml",
+    "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v${local.prometheus-operator_crd_version}/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml",
+    "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v${local.prometheus-operator_crd_version}/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml",
+    "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v${local.prometheus-operator_crd_version}/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml",
+    "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v${local.prometheus-operator_crd_version}/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml",
+    "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v${local.prometheus-operator_crd_version}/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml"
+  ]
+
+  prometheus-operator_chart = "https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-${local.kube-prometheus-stack.chart_version}/charts/kube-prometheus-stack/Chart.yaml"
+
+}
+
+data "http" "prometheus-operator_version" {
+  count = local.kube-prometheus-stack.manage_crds ? 1 : 0
+  url   = local.prometheus-operator_chart
+}
+
+data "http" "prometheus-operator_crds" {
+  for_each = local.kube-prometheus-stack.manage_crds ? toset(local.prometheus-operator_crds) : []
+  url      = each.key
+}
+
+resource "kubectl_manifest" "prometheus-operator_crds" {
+  for_each  = data.http.prometheus-operator_crds
+  yaml_body = each.value.body
+}

--- a/kube-prometheus.tf
+++ b/kube-prometheus.tf
@@ -1,4 +1,5 @@
 locals {
+
   kube-prometheus-stack = merge(
     local.helm_defaults,
     {
@@ -10,6 +11,7 @@ locals {
       enabled                = false
       allowed_cidrs          = ["0.0.0.0/0"]
       default_network_policy = true
+      manage_crds            = true
     },
     var.kube-prometheus-stack
   )

--- a/modules/aws/README.md
+++ b/modules/aws/README.md
@@ -36,6 +36,7 @@ This module can uses [IRSA](https://aws.amazon.com/blogs/opensource/introducing-
 | <a name="provider_flux"></a> [flux](#provider\_flux) | ~> 0.1 |
 | <a name="provider_github"></a> [github](#provider\_github) | ~> 4.5 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | ~> 2.0 |
+| <a name="provider_http"></a> [http](#provider\_http) | n/a |
 | <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | ~> 1.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | ~> 2.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
@@ -128,6 +129,8 @@ This module can uses [IRSA](https://aws.amazon.com/blogs/opensource/introducing-
 | [kubectl_manifest.cert-manager_cluster_issuers](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
 | [kubectl_manifest.cert-manager_csi_driver](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
 | [kubectl_manifest.cni-metrics-helper](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
+| [kubectl_manifest.kong_crds](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
+| [kubectl_manifest.prometheus-operator_crds](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
 | [kubectl_manifest.sync](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
 | [kubernetes_namespace.admiralty](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 | [kubernetes_namespace.aws-ebs-csi-driver](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
@@ -277,7 +280,10 @@ This module can uses [IRSA](https://aws.amazon.com/blogs/opensource/introducing-
 | [flux_install.main](https://registry.terraform.io/providers/fluxcd/flux/latest/docs/data-sources/install) | data source |
 | [flux_sync.main](https://registry.terraform.io/providers/fluxcd/flux/latest/docs/data-sources/sync) | data source |
 | [github_repository.main](https://registry.terraform.io/providers/integrations/github/latest/docs/data-sources/repository) | data source |
+| [http_http.kong_crds](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
+| [http_http.prometheus-operator_crds](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
 | [kubectl_file_documents.apply](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/data-sources/file_documents) | data source |
+| [kubectl_file_documents.kong_crds](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/data-sources/file_documents) | data source |
 | [kubectl_file_documents.sync](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/data-sources/file_documents) | data source |
 | [kubectl_path_documents.cert-manager_cluster_issuers](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/data-sources/path_documents) | data source |
 | [kubectl_path_documents.cert-manager_csi_driver](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/data-sources/path_documents) | data source |

--- a/modules/aws/README.md
+++ b/modules/aws/README.md
@@ -282,6 +282,7 @@ This module can uses [IRSA](https://aws.amazon.com/blogs/opensource/introducing-
 | [github_repository.main](https://registry.terraform.io/providers/integrations/github/latest/docs/data-sources/repository) | data source |
 | [http_http.kong_crds](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
 | [http_http.prometheus-operator_crds](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
+| [http_http.prometheus-operator_version](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
 | [kubectl_file_documents.apply](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/data-sources/file_documents) | data source |
 | [kubectl_file_documents.kong_crds](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/data-sources/file_documents) | data source |
 | [kubectl_file_documents.sync](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/data-sources/file_documents) | data source |

--- a/modules/aws/kong-crds.tf
+++ b/modules/aws/kong-crds.tf
@@ -1,0 +1,1 @@
+../../kong-crds.tf

--- a/modules/aws/kube-prometheus-crd.tf
+++ b/modules/aws/kube-prometheus-crd.tf
@@ -1,0 +1,1 @@
+../../kube-prometheus-crd.tf

--- a/modules/aws/kube-prometheus.tf
+++ b/modules/aws/kube-prometheus.tf
@@ -24,6 +24,7 @@ locals {
       default_network_policy            = true
       default_global_requests           = false
       default_global_limits             = false
+      manage_crds                       = true
     },
     var.kube-prometheus-stack
   )

--- a/modules/scaleway/README.md
+++ b/modules/scaleway/README.md
@@ -34,6 +34,7 @@ User guides, feature documentation and examples are available [here](https://git
 | <a name="provider_flux"></a> [flux](#provider\_flux) | ~> 0.1 |
 | <a name="provider_github"></a> [github](#provider\_github) | ~> 4.5 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | ~> 2.0 |
+| <a name="provider_http"></a> [http](#provider\_http) | n/a |
 | <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | ~> 1.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | ~> 2.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
@@ -82,6 +83,7 @@ No modules.
 | [kubectl_manifest.apply](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
 | [kubectl_manifest.cert-manager_cluster_issuers](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
 | [kubectl_manifest.cert-manager_csi_driver](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
+| [kubectl_manifest.kong_crds](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
 | [kubectl_manifest.sync](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
 | [kubernetes_namespace.admiralty](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 | [kubernetes_namespace.cert-manager](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
@@ -185,7 +187,9 @@ No modules.
 | [flux_install.main](https://registry.terraform.io/providers/fluxcd/flux/latest/docs/data-sources/install) | data source |
 | [flux_sync.main](https://registry.terraform.io/providers/fluxcd/flux/latest/docs/data-sources/sync) | data source |
 | [github_repository.main](https://registry.terraform.io/providers/integrations/github/latest/docs/data-sources/repository) | data source |
+| [http_http.kong_crds](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
 | [kubectl_file_documents.apply](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/data-sources/file_documents) | data source |
+| [kubectl_file_documents.kong_crds](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/data-sources/file_documents) | data source |
 | [kubectl_file_documents.sync](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/data-sources/file_documents) | data source |
 | [kubectl_path_documents.cert-manager_cluster_issuers](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/data-sources/path_documents) | data source |
 | [kubectl_path_documents.cert-manager_csi_driver](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/data-sources/path_documents) | data source |

--- a/modules/scaleway/kong-crds.tf
+++ b/modules/scaleway/kong-crds.tf
@@ -1,0 +1,1 @@
+../../kong-crds.tf

--- a/modules/scaleway/kube-prometheus.tf
+++ b/modules/scaleway/kube-prometheus.tf
@@ -18,6 +18,7 @@ locals {
       default_network_policy  = true
       default_global_requests = false
       default_global_limits   = false
+      manage_crds             = true
     },
     var.kube-prometheus-stack
   )


### PR DESCRIPTION
# Handle CRDs for Prometheus and Kong

## Description

This PR adds logic to handle CRDs lifecycle with TF because it is not handle automatically by Helm 3 and few chart implements CRDs lifecycle (eg. cert-manager does).

Fixes #70 

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/particuleio/terraform-kubernetes-addons/#doc-generation
