### PR TITLE
feat: option to allow pushing the flux2 configs to a different branch

### DIFF
--- a/flux2.tf
+++ b/flux2.tf
@@ -17,8 +17,8 @@ locals {
       github_token             = ""
       repository               = "gitops"
       repository_visibility    = "public"
-      branch                   = "flux-system"
-      flux_sync_branch         = "main"
+      branch                   = "main"
+      flux_sync_branch         = ""
       default_components       = ["source-controller", "kustomize-controller", "helm-controller", "notification-controller"]
       components               = []
       provider                 = "github"
@@ -96,7 +96,7 @@ data "flux_sync" "main" {
   count       = local.flux2["enabled"] ? 1 : 0
   target_path = local.flux2["target_path"]
   url         = local.flux2["github_url"]
-  branch      = local.flux2["flux_sync_branch"] ? local.flux2["flux_sync_branch"] : local.flux2["branch"]
+  branch      = local.flux2["flux_sync_branch"] != "" ? local.flux2["flux_sync_branch"] : local.flux2["branch"]
   namespace   = local.flux2["namespace"]
 }
 

--- a/flux2.tf
+++ b/flux2.tf
@@ -17,7 +17,8 @@ locals {
       github_token             = ""
       repository               = "gitops"
       repository_visibility    = "public"
-      branch                   = "main"
+      branch                   = "flux-system"
+      flux_sync_branch         = "main"
       default_components       = ["source-controller", "kustomize-controller", "helm-controller", "notification-controller"]
       components               = []
       provider                 = "github"
@@ -95,7 +96,7 @@ data "flux_sync" "main" {
   count       = local.flux2["enabled"] ? 1 : 0
   target_path = local.flux2["target_path"]
   url         = local.flux2["github_url"]
-  branch      = local.flux2["branch"]
+  branch      = local.flux2["flux_sync_branch"] ? local.flux2["flux_sync_branch"] : local.flux2["branch"]
   namespace   = local.flux2["namespace"]
 }
 


### PR DESCRIPTION
# option to allow pushing the flux2 configs to a different branch

## Description

I have a mono repo and want to keep the flux2 configs in a different branch and control when they are merged into master so i can lock down the master branch

This change adds an optional variable `flux_sync_branch` so we can push flux config to a different branch but keep it in sync with the master branch

eg:
```
branch                   = "flux-system"
flux_sync_branch         = "main"
```

with something like this, the changes are pushed to flux-system branch but the k8s cluster using flux is configured to sync with the main branch

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/particuleio/terraform-kubernetes-addons/#doc-generation
