### PR TITLE
fix: Use arn partition variable in aws ebs iam policy

### DIFF
--- a/modules/aws/aws-ebs-csi-driver.tf
+++ b/modules/aws/aws-ebs-csi-driver.tf
@@ -63,7 +63,7 @@ module "iam_assumable_role_aws-ebs-csi-driver" {
 resource "aws_iam_policy" "aws-ebs-csi-driver" {
   count  = local.aws-ebs-csi-driver["enabled"] && local.aws-ebs-csi-driver["create_iam_resources_irsa"] ? 1 : 0
   name   = "tf-${var.cluster-name}-${local.aws-ebs-csi-driver["name"]}"
-  policy = local.aws-ebs-csi-driver["iam_policy_override"] == null ? file("${path.module}/iam/aws-ebs-csi-driver.json") : local.aws-ebs-csi-driver["iam_policy_override"]
+  policy = local.aws-ebs-csi-driver["iam_policy_override"] == null ? templatefile("${path.module}/iam/aws-ebs-csi-driver.json", { arn-partition = var.arn-partition }) : local.aws-ebs-csi-driver["iam_policy_override"]
 }
 
 resource "kubernetes_namespace" "aws-ebs-csi-driver" {

--- a/modules/aws/iam/aws-ebs-csi-driver.json
+++ b/modules/aws/iam/aws-ebs-csi-driver.json
@@ -23,8 +23,8 @@
         "ec2:CreateTags"
       ],
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:${arn-partition}:ec2:*:*:volume/*",
+        "arn:${arn-partition}:ec2:*:*:snapshot/*"
       ],
       "Condition": {
         "StringEquals": {
@@ -41,8 +41,8 @@
         "ec2:DeleteTags"
       ],
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:${arn-partition}:ec2:*:*:volume/*",
+        "arn:${arn-partition}:ec2:*:*:snapshot/*"
       ]
     },
     {


### PR DESCRIPTION
# Pull request title

fix: Use arn partition variable in aws ebs iam policy

## Description

This is a follow up after #334 merged. The aws policy was then changed in #346 but did not use the arn partition variable. This PR just updates the iam policy to use the arn partition variable

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/particuleio/terraform-kubernetes-addons/#doc-generation
