### PR TITLE
fix: Use arn parttion variable in aws ebs iam policy (#378)

### DIFF
--- a/modules/aws/aws-ebs-csi-driver.tf
+++ b/modules/aws/aws-ebs-csi-driver.tf
@@ -63,7 +63,7 @@ module "iam_assumable_role_aws-ebs-csi-driver" {
 resource "aws_iam_policy" "aws-ebs-csi-driver" {
   count  = local.aws-ebs-csi-driver["enabled"] && local.aws-ebs-csi-driver["create_iam_resources_irsa"] ? 1 : 0
   name   = "tf-${var.cluster-name}-${local.aws-ebs-csi-driver["name"]}"
-  policy = local.aws-ebs-csi-driver["iam_policy_override"] == null ? file("${path.module}/iam/aws-ebs-csi-driver.json") : local.aws-ebs-csi-driver["iam_policy_override"]
+  policy = local.aws-ebs-csi-driver["iam_policy_override"] == null ? templatefile("${path.module}/iam/aws-ebs-csi-driver.json", { arn-partition = var.arn-partition }) : local.aws-ebs-csi-driver["iam_policy_override"]
 }
 
 resource "kubernetes_namespace" "aws-ebs-csi-driver" {

--- a/modules/aws/iam/aws-ebs-csi-driver.json
+++ b/modules/aws/iam/aws-ebs-csi-driver.json
@@ -23,8 +23,8 @@
         "ec2:CreateTags"
       ],
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:${arn-partition}:ec2:*:*:volume/*",
+        "arn:${arn-partition}:ec2:*:*:snapshot/*"
       ],
       "Condition": {
         "StringEquals": {
@@ -41,8 +41,8 @@
         "ec2:DeleteTags"
       ],
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:${arn-partition}:ec2:*:*:volume/*",
+        "arn:${arn-partition}:ec2:*:*:snapshot/*"
       ]
     },
     {


### PR DESCRIPTION
Signed-off-by: Traver Tischio <travertischio@gmail.com>

Co-authored-by: Kevin Lefevre <kevin@particule.io>
