### PR TITLE
feat: add custom encryption for CSI driver

### DIFF
--- a/modules/aws/README.md
+++ b/modules/aws/README.md
@@ -84,7 +84,9 @@ This module can uses [IRSA](https://aws.amazon.com/blogs/opensource/introducing-
 | [aws_iam_policy.thanos](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.thanos-storegateway](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.vault](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_kms_alias.aws-ebs-csi-driver](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_alias.vault](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
+| [aws_kms_key.aws-ebs-csi-driver](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_kms_key.vault](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [github_branch_default.main](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/branch_default) | resource |
 | [github_repository.main](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository) | resource |
@@ -268,6 +270,9 @@ This module can uses [IRSA](https://aws.amazon.com/blogs/opensource/introducing-
 | [tls_self_signed_cert.loki-stack-ca-cert](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/self_signed_cert) | resource |
 | [tls_self_signed_cert.thanos-tls-querier-ca-cert](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/self_signed_cert) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.aws-ebs-csi-driver](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.aws-ebs-csi-driver_default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.aws-ebs-csi-driver_kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.aws-for-fluent-bit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.cert-manager](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.cluster-autoscaler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/modules/aws/aws-ebs-csi-driver.tf
+++ b/modules/aws/aws-ebs-csi-driver.tf
@@ -80,7 +80,7 @@ data "aws_iam_policy_document" "aws-ebs-csi-driver_default" {
 resource "aws_iam_policy" "aws-ebs-csi-driver" {
   count  = local.aws-ebs-csi-driver["enabled"] && local.aws-ebs-csi-driver["create_iam_resources_irsa"] ? 1 : 0
   name   = "tf-${var.cluster-name}-${local.aws-ebs-csi-driver["name"]}"
-  policy = local.aws-ebs-csi-driver["iam_policy_override"] == null ? templatefile("${path.module}/iam/aws-ebs-csi-driver.json", { arn-partition = var.arn-partition }) : local.aws-ebs-csi-driver["iam_policy_override"]
+  policy = local.aws-ebs-csi-driver["iam_policy_override"] == null ? data.aws_iam_policy_document.aws-ebs-csi-driver.0.json : local.aws-ebs-csi-driver["iam_policy_override"]
   tags   = local.tags
 }
 

--- a/modules/aws/aws-ebs-csi-driver.tf
+++ b/modules/aws/aws-ebs-csi-driver.tf
@@ -19,17 +19,20 @@ locals {
       enabled                   = false
       iam_policy_override       = null
       default_network_policy    = true
+      create_kms_key            = true
+      existing_kms_key_arn      = null
+      override_kms_alias        = null
+      use_kms                   = false
+      use_encryption            = false
+      extra_sc_parameters       = {}
     },
     var.aws-ebs-csi-driver
   )
 
   values_aws-ebs-csi-driver = <<VALUES
-enableVolumeScheduling: true
-enableVolumeResizing: true
-enableVolumeSnapshot: true
-extraCreateMetadata: true
-k8sTagClusterId: ${var.cluster-name}
 controller:
+  k8sTagClusterId: ${var.cluster-name}
+  extraCreateMetadata: true
   priorityClassName: ${local.priority-class["create"] ? kubernetes_priority_class.kubernetes_addons[0].metadata[0].name : ""}
   serviceAccount:
     name: ${local.aws-ebs-csi-driver["service_account_names"]["controller"]}
@@ -54,6 +57,24 @@ module "iam_assumable_role_aws-ebs-csi-driver" {
     "system:serviceaccount:${local.aws-ebs-csi-driver["namespace"]}:${local.aws-ebs-csi-driver["service_account_names"]["node"]}"
   ]
   tags = local.tags
+}
+
+data "aws_iam_policy_document" "aws-ebs-csi-driver" {
+  count = local.aws-ebs-csi-driver.enabled && local.aws-ebs-csi-driver.create_iam_resources_irsa ? 1 : 0
+  source_policy_documents = [
+    data.aws_iam_policy_document.aws-ebs-csi-driver_default.0.json,
+    local.aws-ebs-csi-driver.use_kms && local.aws-ebs-csi-driver.use_encryption ? data.aws_iam_policy_document.aws-ebs-csi-driver_kms.0.json : jsonencode({})
+  ]
+}
+
+data "aws_iam_policy_document" "aws-ebs-csi-driver_kms" {
+  count       = local.aws-ebs-csi-driver.use_kms && local.aws-ebs-csi-driver.use_encryption ? 1 : 0
+  source_json = templatefile("${path.module}/iam/aws-ebs-csi-driver_kms.json", { kmsKeyId = local.aws-ebs-csi-driver.create_kms_key ? aws_kms_key.aws-ebs-csi-driver.0.arn : local.aws-ebs-csi-driver.existing_kms_key_arn })
+}
+
+data "aws_iam_policy_document" "aws-ebs-csi-driver_default" {
+  count       = local.aws-ebs-csi-driver.enabled && local.aws-ebs-csi-driver.create_iam_resources_irsa ? 1 : 0
+  source_json = templatefile("${path.module}/iam/aws-ebs-csi-driver.json", { arn-partition = var.arn-partition })
 }
 
 resource "aws_iam_policy" "aws-ebs-csi-driver" {
@@ -114,6 +135,14 @@ resource "kubernetes_storage_class" "aws-ebs-csi-driver" {
   storage_provisioner    = "ebs.csi.aws.com"
   volume_binding_mode    = "WaitForFirstConsumer"
   allow_volume_expansion = true
+
+  parameters = merge(
+    {
+      encrypted = local.aws-ebs-csi-driver.use_encryption
+      kmsKeyId  = local.aws-ebs-csi-driver.use_encryption ? local.aws-ebs-csi-driver.use_kms ? local.aws-ebs-csi-driver.create_kms_key ? aws_kms_key.aws-ebs-csi-driver.0.arn : local.aws-ebs-csi-driver.existing_kms_key_arn : "" : ""
+    },
+    local.aws-ebs-csi-driver.extra_sc_parameters
+  )
 }
 
 resource "kubernetes_network_policy" "aws-ebs-csi-driver_default_deny" {
@@ -155,4 +184,15 @@ resource "kubernetes_network_policy" "aws-ebs-csi-driver_allow_namespace" {
 
     policy_types = ["Ingress"]
   }
+}
+
+resource "aws_kms_key" "aws-ebs-csi-driver" {
+  count = local.aws-ebs-csi-driver.enabled && local.aws-ebs-csi-driver.use_kms && local.aws-ebs-csi-driver.create_kms_key ? 1 : 0
+  tags  = local.tags
+}
+
+resource "aws_kms_alias" "aws-ebs-csi-driver" {
+  count         = local.aws-ebs-csi-driver.enabled && local.aws-ebs-csi-driver.use_kms && local.aws-ebs-csi-driver.create_kms_key ? 1 : 0
+  name          = "alias/aws-ebs-csi-driver-${local.aws-ebs-csi-driver.override_kms_alias != null ? local.aws-ebs-csi-driver.override_kms_alias : var.cluster-name}"
+  target_key_id = aws_kms_key.aws-ebs-csi-driver.0.id
 }

--- a/modules/aws/iam/aws-ebs-csi-driver_kms.json
+++ b/modules/aws/iam/aws-ebs-csi-driver_kms.json
@@ -1,0 +1,30 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "kms:CreateGrant",
+        "kms:ListGrants",
+        "kms:RevokeGrant"
+      ],
+      "Resource": ["${kmsKeyId}"],
+      "Condition": {
+        "Bool": {
+          "kms:GrantIsForAWSResource": "true"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey"
+      ],
+      "Resource": ["${kmsKeyId}"]
+    }
+  ]
+}


### PR DESCRIPTION
# Enable encryption with AWS EBS CSI

## Description

This PR adds encryption with custom KMS Key for AWS CSI Driver:
* AWS Default KMS Key
* TF Generated KMS Key
* Existing KMS Key

### Checklist

- [x] CI tests are passing
- [X] README.md has been updated after any changes to variables and outputs. See https://github.com/particuleio/terraform-kubernetes-addons/#doc-generation
