### PR TITLE
Fix(Kyverno): install CRDs before installing the Helm Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ No modules.
 | [helm_release.kong](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.kube-prometheus-stack](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.kyverno](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [helm_release.kyverno-crds](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.loki-stack](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.metrics-server](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.node-problem-detector](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |

--- a/helm-dependencies.yaml
+++ b/helm-dependencies.yaml
@@ -63,7 +63,10 @@ dependencies:
     version: 18.0.10
     repository: https://prometheus-community.github.io/helm-charts
   - name: kyverno
-    version: v1.4.2
+    version: v2.0.2
+    repository: https://kyverno.github.io/kyverno/
+  - name: kyverno-crds
+    version: v2.0.2
     repository: https://kyverno.github.io/kyverno/
   - name: loki-stack
     version: 2.4.1

--- a/kyverno.tf
+++ b/kyverno.tf
@@ -73,7 +73,7 @@ resource "helm_release" "kyverno" {
   namespace = local.kyverno["create_ns"] ? kubernetes_namespace.kyverno.*.metadata.0.name[count.index] : local.kyverno["namespace"]
 
   depends_on = [
-    helm_release.kube-prometheus-stack,
+    kubectl_manifest.prometheus-operator_crds,
     helm_release.kyverno-crds
   ]
 }
@@ -104,10 +104,6 @@ resource "helm_release" "kyverno-crds" {
     local.kyverno["extra_values"]
   ]
   namespace = local.kyverno["create_ns"] ? kubernetes_namespace.kyverno.*.metadata.0.name[count.index] : local.kyverno["namespace"]
-
-  depends_on = [
-    helm_release.kube-prometheus-stack
-  ]
 }
 
 resource "kubernetes_network_policy" "kyverno_default_deny" {

--- a/modules/aws/README.md
+++ b/modules/aws/README.md
@@ -114,6 +114,7 @@ This module can uses [IRSA](https://aws.amazon.com/blogs/opensource/introducing-
 | [helm_release.kong](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.kube-prometheus-stack](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.kyverno](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [helm_release.kyverno-crds](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.loki-stack](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.metrics-server](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.node-problem-detector](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |

--- a/modules/azure/README.md
+++ b/modules/azure/README.md
@@ -55,6 +55,7 @@ No modules.
 | [helm_release.kong](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.kube-prometheus-stack](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.kyverno](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [helm_release.kyverno-crds](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.loki-stack](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.node-problem-detector](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.prometheus-adapter](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |

--- a/modules/scaleway/README.md
+++ b/modules/scaleway/README.md
@@ -69,6 +69,7 @@ No modules.
 | [helm_release.kong](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.kube-prometheus-stack](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.kyverno](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [helm_release.kyverno-crds](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.loki-stack](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.prometheus-adapter](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.prometheus-blackbox-exporter](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |


### PR DESCRIPTION
Kyverno stores its CRDs in another Helm Chart

# Install Kyverno CRDs

## Description

Closes #478

Kyverno 2.0 separates the installation of Kyverno in the Kubernetes Cluster and the installation of the Custom Resource Definitions.
If required, install the CRDs beforehand.

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/particuleio/terraform-kubernetes-addons/#doc-generation
