### PR TITLE
fix: broken thanos-replicate grafana dashboard link

### DIFF
--- a/modules/aws/kube-prometheus.tf
+++ b/modules/aws/kube-prometheus.tf
@@ -249,7 +249,7 @@ grafana:
       thanos-rule:
         url: https://raw.githubusercontent.com/thanos-io/thanos/master/examples/dashboards/rule.json
       thanos-replicate:
-        url: https://raw.githubusercontent.com/thanos-io/thanos/master/examples/dashboards/bucket_replicate.json
+        url: https://raw.githubusercontent.com/thanos-io/thanos/master/examples/dashboards/bucket-replicate.json
 VALUES
 
   thanos_store_config_default = <<VALUES


### PR DESCRIPTION
# Fixes the broken thanos bucket replication grafana dashboard link

## Description

Installing v2.40.1 with kube-prometheus-stack enabled causes crashloopbackoff in grafana pod launch. 
curl command below fails with 404 and returns code 22.
`curl -skf --connect-timeout 60 --max-time 60 -H 'Accept: application/json' -H 'Content-Type: application/json;charset=UTF-8' https://raw.githubusercontent.com/thanos-io/thanos/master/examples/dashboards/bucket_replicate.json`

The correct url is as below:
https://raw.githubusercontent.com/thanos-io/thanos/master/examples/dashboards/bucket-replicate.json

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/particuleio/terraform-kubernetes-addons/#doc-generation
