### PR TITLE
wip: use eks role module instead of assumable

### DIFF
--- a/modules/aws/README.md
+++ b/modules/aws/README.md
@@ -47,27 +47,27 @@ This module can uses [IRSA](https://aws.amazon.com/blogs/opensource/introducing-
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_iam_assumable_role_aws-ebs-csi-driver"></a> [iam\_assumable\_role\_aws-ebs-csi-driver](#module\_iam\_assumable\_role\_aws-ebs-csi-driver) | terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc | ~> 4.0 |
-| <a name="module_iam_assumable_role_aws-efs-csi-driver"></a> [iam\_assumable\_role\_aws-efs-csi-driver](#module\_iam\_assumable\_role\_aws-efs-csi-driver) | terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc | ~> 4.0 |
-| <a name="module_iam_assumable_role_aws-for-fluent-bit"></a> [iam\_assumable\_role\_aws-for-fluent-bit](#module\_iam\_assumable\_role\_aws-for-fluent-bit) | terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc | ~> 4.0 |
-| <a name="module_iam_assumable_role_aws-load-balancer-controller"></a> [iam\_assumable\_role\_aws-load-balancer-controller](#module\_iam\_assumable\_role\_aws-load-balancer-controller) | terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc | ~> 4.0 |
-| <a name="module_iam_assumable_role_cert-manager"></a> [iam\_assumable\_role\_cert-manager](#module\_iam\_assumable\_role\_cert-manager) | terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc | ~> 4.0 |
-| <a name="module_iam_assumable_role_cluster-autoscaler"></a> [iam\_assumable\_role\_cluster-autoscaler](#module\_iam\_assumable\_role\_cluster-autoscaler) | terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc | ~> 4.0 |
-| <a name="module_iam_assumable_role_cni-metrics-helper"></a> [iam\_assumable\_role\_cni-metrics-helper](#module\_iam\_assumable\_role\_cni-metrics-helper) | terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc | ~> 4.0 |
-| <a name="module_iam_assumable_role_external-dns"></a> [iam\_assumable\_role\_external-dns](#module\_iam\_assumable\_role\_external-dns) | terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc | ~> 4.0 |
-| <a name="module_iam_assumable_role_kube-prometheus-stack_grafana"></a> [iam\_assumable\_role\_kube-prometheus-stack\_grafana](#module\_iam\_assumable\_role\_kube-prometheus-stack\_grafana) | terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc | ~> 4.0 |
-| <a name="module_iam_assumable_role_kube-prometheus-stack_thanos"></a> [iam\_assumable\_role\_kube-prometheus-stack\_thanos](#module\_iam\_assumable\_role\_kube-prometheus-stack\_thanos) | terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc | ~> 4.0 |
-| <a name="module_iam_assumable_role_loki-stack"></a> [iam\_assumable\_role\_loki-stack](#module\_iam\_assumable\_role\_loki-stack) | terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc | ~> 4.0 |
-| <a name="module_iam_assumable_role_prometheus-cloudwatch-exporter"></a> [iam\_assumable\_role\_prometheus-cloudwatch-exporter](#module\_iam\_assumable\_role\_prometheus-cloudwatch-exporter) | terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc | ~> 4.0 |
-| <a name="module_iam_assumable_role_thanos"></a> [iam\_assumable\_role\_thanos](#module\_iam\_assumable\_role\_thanos) | terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc | ~> 4.0 |
-| <a name="module_iam_assumable_role_thanos-storegateway"></a> [iam\_assumable\_role\_thanos-storegateway](#module\_iam\_assumable\_role\_thanos-storegateway) | terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc | ~> 4.0 |
-| <a name="module_iam_assumable_role_vault"></a> [iam\_assumable\_role\_vault](#module\_iam\_assumable\_role\_vault) | terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc | ~> 4.0 |
-| <a name="module_iam_assumable_role_velero"></a> [iam\_assumable\_role\_velero](#module\_iam\_assumable\_role\_velero) | terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc | ~> 4.0 |
+| <a name="module_iam_eks_role_aws-ebs-csi-driver"></a> [iam\_eks\_role\_aws-ebs-csi-driver](#module\_iam\_eks\_role\_aws-ebs-csi-driver) | terraform-aws-modules/iam/aws//modules/iam-eks-role | ~> 4.0 |
+| <a name="module_iam_eks_role_aws-efs-csi-driver"></a> [iam\_eks\_role\_aws-efs-csi-driver](#module\_iam\_eks\_role\_aws-efs-csi-driver) | terraform-aws-modules/iam/aws//modules/iam-eks-role | ~> 4.0 |
+| <a name="module_iam_eks_role_aws-for-fluent-bit"></a> [iam\_eks\_role\_aws-for-fluent-bit](#module\_iam\_eks\_role\_aws-for-fluent-bit) | terraform-aws-modules/iam/aws//modules/iam-eks-role | ~> 4.0 |
+| <a name="module_iam_eks_role_aws-load-balancer-controller"></a> [iam\_eks\_role\_aws-load-balancer-controller](#module\_iam\_eks\_role\_aws-load-balancer-controller) | terraform-aws-modules/iam/aws//modules/iam-eks-role | ~> 4.0 |
+| <a name="module_iam_eks_role_cert-manager"></a> [iam\_eks\_role\_cert-manager](#module\_iam\_eks\_role\_cert-manager) | terraform-aws-modules/iam/aws//modules/iam-eks-role | ~> 4.0 |
+| <a name="module_iam_eks_role_cluster-autoscaler"></a> [iam\_eks\_role\_cluster-autoscaler](#module\_iam\_eks\_role\_cluster-autoscaler) | terraform-aws-modules/iam/aws//modules/iam-eks-role | ~> 4.0 |
+| <a name="module_iam_eks_role_cni-metrics-helper"></a> [iam\_eks\_role\_cni-metrics-helper](#module\_iam\_eks\_role\_cni-metrics-helper) | terraform-aws-modules/iam/aws//modules/iam-eks-role | ~> 4.0 |
+| <a name="module_iam_eks_role_external-dns"></a> [iam\_eks\_role\_external-dns](#module\_iam\_eks\_role\_external-dns) | terraform-aws-modules/iam/aws//modules/iam-eks-role | ~> 4.0 |
+| <a name="module_iam_eks_role_kube-prometheus-stack_grafana"></a> [iam\_eks\_role\_kube-prometheus-stack\_grafana](#module\_iam\_eks\_role\_kube-prometheus-stack\_grafana) | terraform-aws-modules/iam/aws//modules/iam-eks-role | ~> 4.0 |
+| <a name="module_iam_eks_role_kube-prometheus-stack_thanos"></a> [iam\_eks\_role\_kube-prometheus-stack\_thanos](#module\_iam\_eks\_role\_kube-prometheus-stack\_thanos) | terraform-aws-modules/iam/aws//modules/iam-eks-role | ~> 4.0 |
+| <a name="module_iam_eks_role_loki-stack"></a> [iam\_eks\_role\_loki-stack](#module\_iam\_eks\_role\_loki-stack) | terraform-aws-modules/iam/aws//modules/iam-eks-role | ~> 4.0 |
+| <a name="module_iam_eks_role_prometheus-cloudwatch-exporter"></a> [iam\_eks\_role\_prometheus-cloudwatch-exporter](#module\_iam\_eks\_role\_prometheus-cloudwatch-exporter) | terraform-aws-modules/iam/aws//modules/iam-eks-role | ~> 4.0 |
+| <a name="module_iam_eks_role_thanos"></a> [iam\_eks\_role\_thanos](#module\_iam\_eks\_role\_thanos) | terraform-aws-modules/iam/aws//modules/iam-eks-role | ~> 4.0 |
+| <a name="module_iam_eks_role_thanos-storegateway"></a> [iam\_eks\_role\_thanos-storegateway](#module\_iam\_eks\_role\_thanos-storegateway) | terraform-aws-modules/iam/aws//modules/iam-eks-role | ~> 4.0 |
+| <a name="module_iam_eks_role_vault"></a> [iam\_eks\_role\_vault](#module\_iam\_eks\_role\_vault) | terraform-aws-modules/iam/aws//modules/iam-eks-role | ~> 4.0 |
+| <a name="module_iam_eks_role_velero"></a> [iam\_eks\_role\_velero](#module\_iam\_eks\_role\_velero) | terraform-aws-modules/iam/aws//modules/iam-eks-role | ~> 4.0 |
 | <a name="module_kube-prometheus-stack_thanos_bucket"></a> [kube-prometheus-stack\_thanos\_bucket](#module\_kube-prometheus-stack\_thanos\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 2.0 |
 | <a name="module_loki_bucket"></a> [loki\_bucket](#module\_loki\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 2.0 |
 | <a name="module_security-group-efs-csi-driver"></a> [security-group-efs-csi-driver](#module\_security-group-efs-csi-driver) | terraform-aws-modules/security-group/aws//modules/nfs | ~> 4.0 |
 | <a name="module_thanos_bucket"></a> [thanos\_bucket](#module\_thanos\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 2.0 |
-| <a name="module_velero_thanos_bucket"></a> [velero\_thanos\_bucket](#module\_velero\_thanos\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 2.0 |
+| <a name="module_velero_bucket"></a> [velero\_bucket](#module\_velero\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 2.0 |
 
 ## Resources
 
@@ -394,7 +394,6 @@ This module can uses [IRSA](https://aws.amazon.com/blogs/opensource/introducing-
 | <a name="input_cluster-name"></a> [cluster-name](#input\_cluster-name) | Name of the Kubernetes cluster | `string` | `"sample-cluster"` | no |
 | <a name="input_cni-metrics-helper"></a> [cni-metrics-helper](#input\_cni-metrics-helper) | Customize cni-metrics-helper deployment, see `cni-metrics-helper.tf` for supported values | `any` | `{}` | no |
 | <a name="input_csi-external-snapshotter"></a> [csi-external-snapshotter](#input\_csi-external-snapshotter) | Customize csi-external-snapshotter, see `csi-external-snapshotter.tf` for supported values | `any` | `{}` | no |
-| <a name="input_eks"></a> [eks](#input\_eks) | EKS cluster inputs | `any` | `{}` | no |
 | <a name="input_external-dns"></a> [external-dns](#input\_external-dns) | Map of map for external-dns configuration: see `external_dns.tf` for supported values | `any` | `{}` | no |
 | <a name="input_flux"></a> [flux](#input\_flux) | Customize Flux chart, see `flux.tf` for supported values | `any` | `{}` | no |
 | <a name="input_flux2"></a> [flux2](#input\_flux2) | Customize Flux chart, see `flux2.tf` for supported values | `any` | `{}` | no |

--- a/modules/aws/aws-for-fluent-bit.tf
+++ b/modules/aws/aws-for-fluent-bit.tf
@@ -34,23 +34,27 @@ cloudWatch:
 serviceAccount:
   name: ${local.aws-for-fluent-bit["service_account_name"]}
   annotations:
-    eks.amazonaws.com/role-arn: "${local.aws-for-fluent-bit["enabled"] && local.aws-for-fluent-bit["create_iam_resources_irsa"] ? module.iam_assumable_role_aws-for-fluent-bit.iam_role_arn : ""}"
+    eks.amazonaws.com/role-arn: "${local.aws-for-fluent-bit["enabled"] && local.aws-for-fluent-bit["create_iam_resources_irsa"] ? module.iam_eks_role_aws-for-fluent-bit.iam_role_arn : ""}"
 tolerations:
 - operator: Exists
 priorityClassName: "${local.priority-class-ds["create"] ? kubernetes_priority_class.kubernetes_addons_ds[0].metadata[0].name : ""}"
 VALUES
 }
 
-module "iam_assumable_role_aws-for-fluent-bit" {
-  source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version                       = "~> 4.0"
-  create_role                   = local.aws-for-fluent-bit["enabled"] && local.aws-for-fluent-bit["create_iam_resources_irsa"]
-  role_name                     = local.aws-for-fluent-bit["name_prefix"]
-  provider_url                  = replace(var.eks["cluster_oidc_issuer_url"], "https://", "")
-  role_policy_arns              = local.aws-for-fluent-bit["enabled"] && local.aws-for-fluent-bit["create_iam_resources_irsa"] ? [aws_iam_policy.aws-for-fluent-bit[0].arn] : []
-  number_of_role_policy_arns    = 1
-  oidc_fully_qualified_subjects = ["system:serviceaccount:${local.aws-for-fluent-bit["namespace"]}:${local.aws-for-fluent-bit["service_account_name"]}"]
-  tags                          = local.tags
+module "iam_eks_role_aws-for-fluent-bit" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-eks-role"
+  version = "~> 4.0"
+
+  create_role      = local.aws-for-fluent-bit["enabled"] && local.aws-for-fluent-bit["create_iam_resources_irsa"]
+  role_name        = local.aws-for-fluent-bit["name_prefix"]
+  role_policy_arns = local.aws-for-fluent-bit["enabled"] && local.aws-for-fluent-bit["create_iam_resources_irsa"] ? [aws_iam_policy.aws-for-fluent-bit[0].arn] : []
+
+  cluster_service_accounts = {
+    "${var.cluster-name}" = [
+      "${local.aws-for-fluent-bit["namespace"]}:${local.aws-for-fluent-bit["service_account_name"]}"
+    ],
+  }
+  tags = local.tags
 }
 
 resource "aws_iam_policy" "aws-for-fluent-bit" {

--- a/modules/aws/cni-metrics-helper.tf
+++ b/modules/aws/cni-metrics-helper.tf
@@ -11,16 +11,20 @@ locals {
   )
 }
 
-module "iam_assumable_role_cni-metrics-helper" {
-  source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version                       = "~> 4.0"
-  create_role                   = local.cni-metrics-helper["enabled"] && local.cni-metrics-helper["create_iam_resources_irsa"]
-  role_name                     = local.cni-metrics-helper["name_prefix"]
-  provider_url                  = replace(var.eks["cluster_oidc_issuer_url"], "https://", "")
-  role_policy_arns              = local.cni-metrics-helper["enabled"] && local.cni-metrics-helper["create_iam_resources_irsa"] ? [aws_iam_policy.cni-metrics-helper[0].arn] : []
-  number_of_role_policy_arns    = 1
-  oidc_fully_qualified_subjects = ["system:serviceaccount:kube-system:cni-metrics-helper"]
-  tags                          = local.tags
+module "iam_eks_role_cni-metrics-helper" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-eks-role"
+  version = "~> 4.0"
+
+  create_role      = local.cni-metrics-helper["enabled"] && local.cni-metrics-helper["create_iam_resources_irsa"]
+  role_name        = local.cni-metrics-helper["name_prefix"]
+  role_policy_arns = local.cni-metrics-helper["enabled"] && local.cni-metrics-helper["create_iam_resources_irsa"] ? [aws_iam_policy.cni-metrics-helper[0].arn] : []
+
+  cluster_service_accounts = {
+    "${var.cluster-name}" = [
+      "kube-system:cni-metrics-helper"
+    ],
+  }
+  tags = local.tags
 }
 
 resource "aws_iam_policy" "cni-metrics-helper" {
@@ -44,7 +48,7 @@ data "aws_iam_policy_document" "cni-metrics-helper" {
 resource "kubectl_manifest" "cni-metrics-helper" {
   count = local.cni-metrics-helper["enabled"] ? 1 : 0
   yaml_body = templatefile("${path.module}/templates/cni-metrics-helper.yaml.tpl", {
-    cni-metrics-helper_role_arn_irsa = local.cni-metrics-helper["create_iam_resources_irsa"] ? module.iam_assumable_role_cni-metrics-helper.iam_role_arn : ""
+    cni-metrics-helper_role_arn_irsa = local.cni-metrics-helper["create_iam_resources_irsa"] ? module.iam_eks_role_cni-metrics-helper.iam_role_arn : ""
     cni-metrics-helper_version       = local.cni-metrics-helper["version"]
   })
 }

--- a/modules/aws/kube-prometheus.tf
+++ b/modules/aws/kube-prometheus.tf
@@ -50,7 +50,7 @@ grafana:
     name: ${local.kube-prometheus-stack["grafana_service_account_name"]}
     nameTest: ${local.kube-prometheus-stack["grafana_service_account_name"]}-test
     annotations:
-      eks.amazonaws.com/role-arn: "${local.kube-prometheus-stack["enabled"] && local.kube-prometheus-stack["grafana_create_iam_resources_irsa"] ? module.iam_assumable_role_kube-prometheus-stack_grafana.iam_role_arn : ""}"
+      eks.amazonaws.com/role-arn: "${local.kube-prometheus-stack["enabled"] && local.kube-prometheus-stack["grafana_create_iam_resources_irsa"] ? module.iam_eks_role_kube-prometheus-stack_grafana.iam_role_arn : ""}"
   adminPassword: ${join(",", random_string.grafana_password.*.result)}
   dashboardProviders:
     dashboardproviders.yaml:
@@ -73,7 +73,7 @@ prometheus:
     create: true
     name: ${local.kube-prometheus-stack["prometheus_service_account_name"]}
     annotations:
-      eks.amazonaws.com/role-arn: "${local.kube-prometheus-stack["enabled"] && local.kube-prometheus-stack["thanos_create_iam_resources_irsa"] ? module.iam_assumable_role_kube-prometheus-stack_thanos.iam_role_arn : ""}"
+      eks.amazonaws.com/role-arn: "${local.kube-prometheus-stack["enabled"] && local.kube-prometheus-stack["thanos_create_iam_resources_irsa"] ? module.iam_eks_role_kube-prometheus-stack_thanos.iam_role_arn : ""}"
   prometheusSpec:
     priorityClassName: ${local.priority-class["create"] ? kubernetes_priority_class.kubernetes_addons[0].metadata[0].name : ""}
 alertmanager:
@@ -266,28 +266,36 @@ VALUES
 
 }
 
-module "iam_assumable_role_kube-prometheus-stack_grafana" {
-  source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version                       = "~> 4.0"
-  create_role                   = local.kube-prometheus-stack["enabled"] && local.kube-prometheus-stack["grafana_create_iam_resources_irsa"]
-  role_name                     = "${local.kube-prometheus-stack["name_prefix"]}-grafana"
-  provider_url                  = replace(var.eks["cluster_oidc_issuer_url"], "https://", "")
-  role_policy_arns              = local.kube-prometheus-stack["enabled"] && local.kube-prometheus-stack["grafana_create_iam_resources_irsa"] ? [aws_iam_policy.kube-prometheus-stack_grafana[0].arn] : []
-  number_of_role_policy_arns    = 1
-  oidc_fully_qualified_subjects = ["system:serviceaccount:${local.kube-prometheus-stack["namespace"]}:${local.kube-prometheus-stack["grafana_service_account_name"]}"]
-  tags                          = local.tags
+module "iam_eks_role_kube-prometheus-stack_grafana" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-eks-role"
+  version = "~> 4.0"
+
+  create_role      = local.kube-prometheus-stack["enabled"] && local.kube-prometheus-stack["grafana_create_iam_resources_irsa"]
+  role_name        = "${local.kube-prometheus-stack["name_prefix"]}-grafana"
+  role_policy_arns = local.kube-prometheus-stack["enabled"] && local.kube-prometheus-stack["grafana_create_iam_resources_irsa"] ? [aws_iam_policy.kube-prometheus-stack_grafana[0].arn] : []
+
+  cluster_service_accounts = {
+    "${var.cluster-name}" = [
+      "${local.kube-prometheus-stack["namespace"]}:${local.kube-prometheus-stack["grafana_service_account_name"]}"
+    ],
+  }
+  tags = local.tags
 }
 
-module "iam_assumable_role_kube-prometheus-stack_thanos" {
-  source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version                       = "~> 4.0"
-  create_role                   = local.kube-prometheus-stack["enabled"] && local.kube-prometheus-stack["thanos_create_iam_resources_irsa"] && local.kube-prometheus-stack["thanos_sidecar_enabled"]
-  role_name                     = "${local.kube-prometheus-stack["name_prefix"]}-thanos"
-  provider_url                  = replace(var.eks["cluster_oidc_issuer_url"], "https://", "")
-  role_policy_arns              = local.kube-prometheus-stack["enabled"] && local.kube-prometheus-stack["thanos_create_iam_resources_irsa"] ? [aws_iam_policy.kube-prometheus-stack_thanos[0].arn] : []
-  number_of_role_policy_arns    = 1
-  oidc_fully_qualified_subjects = ["system:serviceaccount:${local.kube-prometheus-stack["namespace"]}:${local.kube-prometheus-stack["prometheus_service_account_name"]}"]
-  tags                          = local.tags
+module "iam_eks_role_kube-prometheus-stack_thanos" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-eks-role"
+  version = "~> 4.0"
+
+  create_role      = local.kube-prometheus-stack["enabled"] && local.kube-prometheus-stack["thanos_create_iam_resources_irsa"] && local.kube-prometheus-stack["thanos_sidecar_enabled"]
+  role_name        = "${local.kube-prometheus-stack["name_prefix"]}-thanos"
+  role_policy_arns = local.kube-prometheus-stack["enabled"] && local.kube-prometheus-stack["thanos_create_iam_resources_irsa"] ? [aws_iam_policy.kube-prometheus-stack_thanos[0].arn] : []
+
+  cluster_service_accounts = {
+    "${var.cluster-name}" = [
+      "${local.kube-prometheus-stack["namespace"]}:${local.kube-prometheus-stack["prometheus_service_account_name"]}"
+    ],
+  }
+  tags = local.tags
 }
 
 resource "aws_iam_policy" "kube-prometheus-stack_grafana" {

--- a/modules/aws/prometheus-cloudwatch-exporter.tf
+++ b/modules/aws/prometheus-cloudwatch-exporter.tf
@@ -22,24 +22,28 @@ locals {
     serviceMonitor:
       enabled: ${local.kube-prometheus-stack["enabled"] || local.victoria-metrics-k8s-stack["enabled"]}
     aws:
-      role: "${local.prometheus-cloudwatch-exporter["enabled"] && local.prometheus-cloudwatch-exporter["create_iam_resources_irsa"] ? module.iam_assumable_role_prometheus-cloudwatch-exporter.iam_role_arn : ""}"
+      role: "${local.prometheus-cloudwatch-exporter["enabled"] && local.prometheus-cloudwatch-exporter["create_iam_resources_irsa"] ? module.iam_eks_role_prometheus-cloudwatch-exporter.iam_role_arn : ""}"
     serviceAccount:
       name: ${local.prometheus-cloudwatch-exporter["service_account_name"]}
       annotations:
-        eks.amazonaws.com/role-arn: "${local.prometheus-cloudwatch-exporter["enabled"] && local.prometheus-cloudwatch-exporter["create_iam_resources_irsa"] ? module.iam_assumable_role_prometheus-cloudwatch-exporter.iam_role_arn : ""}"
+        eks.amazonaws.com/role-arn: "${local.prometheus-cloudwatch-exporter["enabled"] && local.prometheus-cloudwatch-exporter["create_iam_resources_irsa"] ? module.iam_eks_role_prometheus-cloudwatch-exporter.iam_role_arn : ""}"
     VALUES
 }
 
-module "iam_assumable_role_prometheus-cloudwatch-exporter" {
-  source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version                       = "~> 4.0"
-  create_role                   = local.prometheus-cloudwatch-exporter["enabled"] && local.prometheus-cloudwatch-exporter["create_iam_resources_irsa"]
-  role_name                     = local.prometheus-cloudwatch-exporter["name_prefix"]
-  provider_url                  = replace(var.eks["cluster_oidc_issuer_url"], "https://", "")
-  role_policy_arns              = local.prometheus-cloudwatch-exporter["enabled"] && local.prometheus-cloudwatch-exporter["create_iam_resources_irsa"] ? [aws_iam_policy.prometheus-cloudwatch-exporter[0].arn] : []
-  number_of_role_policy_arns    = 1
-  oidc_fully_qualified_subjects = ["system:serviceaccount:${local.prometheus-cloudwatch-exporter["namespace"]}:${local.prometheus-cloudwatch-exporter["service_account_name"]}"]
-  tags                          = local.tags
+module "iam_eks_role_prometheus-cloudwatch-exporter" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-eks-role"
+  version = "~> 4.0"
+
+  create_role      = local.prometheus-cloudwatch-exporter["enabled"] && local.prometheus-cloudwatch-exporter["create_iam_resources_irsa"]
+  role_name        = local.prometheus-cloudwatch-exporter["name_prefix"]
+  role_policy_arns = local.prometheus-cloudwatch-exporter["enabled"] && local.prometheus-cloudwatch-exporter["create_iam_resources_irsa"] ? [aws_iam_policy.prometheus-cloudwatch-exporter[0].arn] : []
+
+  cluster_service_accounts = {
+    "${var.cluster-name}" = [
+      "${local.prometheus-cloudwatch-exporter["namespace"]}:${local.prometheus-cloudwatch-exporter["service_account_name"]}"
+    ],
+  }
+  tags = local.tags
 }
 
 resource "aws_iam_policy" "prometheus-cloudwatch-exporter" {

--- a/modules/aws/thanos.tf
+++ b/modules/aws/thanos.tf
@@ -33,7 +33,7 @@ locals {
         minAvailable: 1
       serviceAccount:
         annotations:
-          eks.amazonaws.com/role-arn: "${local.thanos["enabled"] && local.thanos["create_iam_resources_irsa"] ? module.iam_assumable_role_thanos.iam_role_arn : ""}"
+          eks.amazonaws.com/role-arn: "${local.thanos["enabled"] && local.thanos["create_iam_resources_irsa"] ? module.iam_eks_role_thanos.iam_role_arn : ""}"
     metrics:
       enabled: true
       serviceMonitor:
@@ -76,7 +76,7 @@ locals {
       enabled: true
       serviceAccount:
         annotations:
-          eks.amazonaws.com/role-arn: "${local.thanos["enabled"] && local.thanos["create_iam_resources_irsa"] ? module.iam_assumable_role_thanos.iam_role_arn : ""}"
+          eks.amazonaws.com/role-arn: "${local.thanos["enabled"] && local.thanos["create_iam_resources_irsa"] ? module.iam_eks_role_thanos.iam_role_arn : ""}"
     storegateway:
       extraFlags:
         - --ignore-deletion-marks-delay=24h
@@ -84,7 +84,7 @@ locals {
       enabled: true
       serviceAccount:
         annotations:
-          eks.amazonaws.com/role-arn: "${local.thanos["enabled"] && local.thanos["create_iam_resources_irsa"] ? module.iam_assumable_role_thanos.iam_role_arn : ""}"
+          eks.amazonaws.com/role-arn: "${local.thanos["enabled"] && local.thanos["create_iam_resources_irsa"] ? module.iam_eks_role_thanos.iam_role_arn : ""}"
       pdb:
         create: true
         minAvailable: 1
@@ -219,18 +219,21 @@ locals {
     VALUES
 }
 
-module "iam_assumable_role_thanos" {
-  source                       = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version                      = "~> 4.0"
-  create_role                  = local.thanos["enabled"] && local.thanos["create_iam_resources_irsa"]
-  role_name                    = local.thanos["name_prefix"]
-  provider_url                 = replace(var.eks["cluster_oidc_issuer_url"], "https://", "")
-  role_policy_arns             = local.thanos["enabled"] && local.thanos["create_iam_resources_irsa"] ? [aws_iam_policy.thanos[0].arn] : []
-  number_of_role_policy_arns   = 1
-  oidc_subjects_with_wildcards = ["system:serviceaccount:${local.thanos["namespace"]}:${local.thanos["name"]}-*"]
-  tags                         = local.tags
-}
+module "iam_eks_role_thanos" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-eks-role"
+  version = "~> 4.0"
 
+  create_role      = local.thanos["enabled"] && local.thanos["create_iam_resources_irsa"]
+  role_name        = local.thanos["name_prefix"]
+  role_policy_arns = local.thanos["enabled"] && local.thanos["create_iam_resources_irsa"] ? [aws_iam_policy.thanos[0].arn] : []
+
+  cluster_service_accounts = {
+    "${var.cluster-name}" = [
+      "${local.thanos["namespace"]}:${local.thanos["name"]}-*"
+    ],
+  }
+  tags = local.tags
+}
 
 resource "aws_iam_policy" "thanos" {
   count  = local.thanos["enabled"] && local.thanos["create_iam_resources_irsa"] ? 1 : 0

--- a/modules/aws/variables-aws.tf
+++ b/modules/aws/variables-aws.tf
@@ -52,12 +52,6 @@ variable "cni-metrics-helper" {
   default     = {}
 }
 
-variable "eks" {
-  description = "EKS cluster inputs"
-  type        = any
-  default     = {}
-}
-
 variable "prometheus-cloudwatch-exporter" {
   description = "Customize prometheus-cloudwatch-exporter chart, see `prometheus-cloudwatch-exporter.tf` for supported values"
   type        = any

--- a/modules/aws/velero.tf
+++ b/modules/aws/velero.tf
@@ -41,7 +41,7 @@ serviceAccount:
   server:
     name: ${local.velero["service_account_name"]}
     annotations:
-      eks.amazonaws.com/role-arn: "${local.velero["enabled"] && local.velero["create_iam_resources_irsa"] ? module.iam_assumable_role_velero.iam_role_arn : ""}"
+      eks.amazonaws.com/role-arn: "${local.velero["enabled"] && local.velero["create_iam_resources_irsa"] ? module.iam_eks_role_velero.iam_role_arn : ""}"
 priorityClassName: ${local.priority-class-ds["create"] ? kubernetes_priority_class.kubernetes_addons_ds[0].metadata[0].name : ""}
 credentials:
   useSecret: false
@@ -62,16 +62,20 @@ VALUES
 
 }
 
-module "iam_assumable_role_velero" {
-  source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version                       = "~> 4.0"
-  create_role                   = local.velero["enabled"] && local.velero["create_iam_resources_irsa"]
-  role_name                     = local.velero["name_prefix"]
-  provider_url                  = replace(var.eks["cluster_oidc_issuer_url"], "https://", "")
-  role_policy_arns              = local.velero["enabled"] && local.velero["create_iam_resources_irsa"] ? [aws_iam_policy.velero[0].arn] : []
-  number_of_role_policy_arns    = 1
-  oidc_fully_qualified_subjects = ["system:serviceaccount:${local.velero["namespace"]}:${local.velero["service_account_name"]}"]
-  tags                          = local.tags
+module "iam_eks_role_velero" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-eks-role"
+  version = "~> 4.0"
+
+  create_role      = local.velero["enabled"] && local.velero["create_iam_resources_irsa"]
+  role_name        = local.velero["name_prefix"]
+  role_policy_arns = local.velero["enabled"] && local.velero["create_iam_resources_irsa"] ? [aws_iam_policy.velero[0].arn] : []
+
+  cluster_service_accounts = {
+    "${var.cluster-name}" = [
+      "${local.velero["namespace"]}:${local.velero["service_account_name"]}"
+    ],
+  }
+  tags = local.tags
 }
 
 resource "aws_iam_policy" "velero" {
@@ -157,7 +161,7 @@ data "aws_iam_policy_document" "velero_kms" {
   }
 }
 
-module "velero_thanos_bucket" {
+module "velero_bucket" {
   create_bucket = local.velero.enabled && local.velero.create_bucket
 
   source  = "terraform-aws-modules/s3-bucket/aws"


### PR DESCRIPTION
BREAKING CHANGE: use terraform-aws-modules/iam-eks-role instead of the
assumable role. Pods using IRSA might need to be restarted as the old
roles will get destroyed and recreated.

Signed-off-by: Kevin Lefevre <kevin@particule.io>

# Pull request title

## Description

Please explain the changes you made here and link to any relevant issues.

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/particuleio/terraform-kubernetes-addons/#doc-generation
