### PR TITLE
fix(ingress-nginx): namespace name label for scaleway

### DIFF
--- a/modules/scaleway/ingress-nginx.tf
+++ b/modules/scaleway/ingress-nginx.tf
@@ -51,6 +51,7 @@ resource "kubernetes_namespace" "ingress-nginx" {
 
   metadata {
     labels = {
+      name                               = local.ingress-nginx["namespace"]
       "${local.labels_prefix}/component" = "ingress"
     }
 


### PR DESCRIPTION
# Add label name to ns for ingress-nginx (scaleway)

## Description

Will fix networkpolicies issued with the helm release.
