### PR TITLE
fix: thanos query dedicated grpc service

### DIFF
--- a/modules/aws/thanos.tf
+++ b/modules/aws/thanos.tf
@@ -54,7 +54,7 @@ locals {
       pdb:
         create: true
         minAvailable: 1
-      stores: ${jsonencode(concat([for k, v in local.thanos-tls-querier : "dnssrv+_grpc._tcp.${v["name"]}-query.${local.thanos["namespace"]}.svc.cluster.local"], [for k, v in local.thanos-storegateway : "dnssrv+_grpc._tcp.${v["name"]}-storegateway.${local.thanos["namespace"]}.svc.cluster.local"]))}
+      stores: ${jsonencode(concat([for k, v in local.thanos-tls-querier : "dnssrv+_grpc._tcp.${v["name"]}-query-grpc.${local.thanos["namespace"]}.svc.cluster.local"], [for k, v in local.thanos-storegateway : "dnssrv+_grpc._tcp.${v["name"]}-storegateway.${local.thanos["namespace"]}.svc.cluster.local"]))}
     queryFrontend:
       extraFlags:
         - --query-frontend.compress-responses

--- a/modules/scaleway/thanos.tf
+++ b/modules/scaleway/thanos.tf
@@ -48,7 +48,7 @@ locals {
       pdb:
         create: true
         minAvailable: 1
-      stores: ${jsonencode(concat([for k, v in local.thanos-tls-querier : "dnssrv+_grpc._tcp.${v["name"]}-query.${local.thanos["namespace"]}.svc.cluster.local"], [for k, v in local.thanos-storegateway : "dnssrv+_grpc._tcp.${v["name"]}-storegateway.${local.thanos["namespace"]}.svc.cluster.local"]))}
+      stores: ${jsonencode(concat([for k, v in local.thanos-tls-querier : "dnssrv+_grpc._tcp.${v["name"]}-query-grpc.${local.thanos["namespace"]}.svc.cluster.local"], [for k, v in local.thanos-storegateway : "dnssrv+_grpc._tcp.${v["name"]}-storegateway.${local.thanos["namespace"]}.svc.cluster.local"]))}
     queryFrontend:
       extraFlags:
         - --query-frontend.compress-responses


### PR DESCRIPTION
Signed-off-by: Kevin Lefevre <kevin@particule.io>

# Fix Thanos Query GRPC

## Description

Thanos charts release v11 adds a separate grpc service.

### Checklist

- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/particuleio/terraform-kubernetes-addons/#doc-generation
