### PR TITLE
feat: upgrade TLS provider to v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ here](https://github.com/particuleio/terraform-kubernetes-addons/blob/master/.gi
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0 |
 | <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | ~> 1.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0, != 2.12 |
-| <a name="requirement_tls"></a> [tls](#requirement\_tls) | ~> 3.0 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | ~> 4.0 |
 
 ## Providers
 
@@ -106,7 +106,7 @@ here](https://github.com/particuleio/terraform-kubernetes-addons/blob/master/.gi
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | ~> 2.0, != 2.12 |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
 | <a name="provider_time"></a> [time](#provider\_time) | n/a |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 3.0 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 4.0 |
 
 ## Modules
 

--- a/linkerd2.tf
+++ b/linkerd2.tf
@@ -193,7 +193,6 @@ resource "tls_private_key" "linkerd_trust_anchor" {
 
 resource "tls_self_signed_cert" "linkerd_trust_anchor" {
   count                 = local.linkerd2["enabled"] && local.linkerd2["trust_anchor_pem"] == null ? 1 : 0
-  key_algorithm         = tls_private_key.linkerd_trust_anchor.0.algorithm
   private_key_pem       = tls_private_key.linkerd_trust_anchor.0.private_key_pem
   validity_period_hours = 87600
   early_renewal_hours   = 78840
@@ -232,7 +231,6 @@ resource "tls_private_key" "webhook_issuer_tls" {
 
 resource "tls_self_signed_cert" "webhook_issuer_tls" {
   count                 = local.linkerd2["enabled"] ? 1 : 0
-  key_algorithm         = tls_private_key.webhook_issuer_tls.0.algorithm
   private_key_pem       = tls_private_key.webhook_issuer_tls.0.private_key_pem
   validity_period_hours = 87600
   early_renewal_hours   = 78840

--- a/loki-stack.tf
+++ b/loki-stack.tf
@@ -103,7 +103,6 @@ resource "tls_private_key" "loki-stack-ca-key" {
 
 resource "tls_self_signed_cert" "loki-stack-ca-cert" {
   count             = local.loki-stack["enabled"] && local.loki-stack["generate_ca"] ? 1 : 0
-  key_algorithm     = "ECDSA"
   private_key_pem   = tls_private_key.loki-stack-ca-key[0].private_key_pem
   is_ca_certificate = true
 
@@ -206,7 +205,6 @@ resource "tls_private_key" "promtail-key" {
 
 resource "tls_cert_request" "promtail-csr" {
   count           = local.loki-stack["enabled"] && local.loki-stack["generate_ca"] && local.loki-stack["create_promtail_cert"] ? 1 : 0
-  key_algorithm   = "ECDSA"
   private_key_pem = tls_private_key.promtail-key[count.index].private_key_pem
 
   subject {
@@ -221,7 +219,6 @@ resource "tls_cert_request" "promtail-csr" {
 resource "tls_locally_signed_cert" "promtail-cert" {
   count              = local.loki-stack["enabled"] && local.loki-stack["generate_ca"] && local.loki-stack["create_promtail_cert"] ? 1 : 0
   cert_request_pem   = tls_cert_request.promtail-csr[count.index].cert_request_pem
-  ca_key_algorithm   = "ECDSA"
   ca_private_key_pem = tls_private_key.loki-stack-ca-key[count.index].private_key_pem
   ca_cert_pem        = tls_self_signed_cert.loki-stack-ca-cert[count.index].cert_pem
 

--- a/modules/aws/README.md
+++ b/modules/aws/README.md
@@ -27,7 +27,7 @@ This module can uses [IRSA](https://aws.amazon.com/blogs/opensource/introducing-
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0 |
 | <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | ~> 1.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0, != 2.12 |
-| <a name="requirement_tls"></a> [tls](#requirement\_tls) | ~> 3.0 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | ~> 4.0 |
 
 ## Providers
 
@@ -42,7 +42,7 @@ This module can uses [IRSA](https://aws.amazon.com/blogs/opensource/introducing-
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | ~> 2.0, != 2.12 |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
 | <a name="provider_time"></a> [time](#provider\_time) | n/a |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 3.0 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 4.0 |
 
 ## Modules
 

--- a/modules/aws/loki-stack.tf
+++ b/modules/aws/loki-stack.tf
@@ -202,7 +202,6 @@ resource "tls_private_key" "loki-stack-ca-key" {
 
 resource "tls_self_signed_cert" "loki-stack-ca-cert" {
   count             = local.loki-stack["enabled"] && local.loki-stack["generate_ca"] ? 1 : 0
-  key_algorithm     = "ECDSA"
   private_key_pem   = tls_private_key.loki-stack-ca-key[0].private_key_pem
   is_ca_certificate = true
 
@@ -305,7 +304,6 @@ resource "tls_private_key" "promtail-key" {
 
 resource "tls_cert_request" "promtail-csr" {
   count           = local.loki-stack["enabled"] && local.loki-stack["generate_ca"] && local.loki-stack["create_promtail_cert"] ? 1 : 0
-  key_algorithm   = "ECDSA"
   private_key_pem = tls_private_key.promtail-key[count.index].private_key_pem
 
   subject {
@@ -320,7 +318,6 @@ resource "tls_cert_request" "promtail-csr" {
 resource "tls_locally_signed_cert" "promtail-cert" {
   count              = local.loki-stack["enabled"] && local.loki-stack["generate_ca"] && local.loki-stack["create_promtail_cert"] ? 1 : 0
   cert_request_pem   = tls_cert_request.promtail-csr[count.index].cert_request_pem
-  ca_key_algorithm   = "ECDSA"
   ca_private_key_pem = tls_private_key.loki-stack-ca-key[count.index].private_key_pem
   ca_cert_pem        = tls_self_signed_cert.loki-stack-ca-cert[count.index].cert_pem
 

--- a/modules/aws/thanos-tls-querier.tf
+++ b/modules/aws/thanos-tls-querier.tf
@@ -135,7 +135,6 @@ resource "tls_private_key" "thanos-tls-querier-cert-key" {
 
 resource "tls_cert_request" "thanos-tls-querier-cert-csr" {
   for_each        = { for k, v in local.thanos-tls-querier : k => v if v["enabled"] && v["generate_cert"] }
-  key_algorithm   = "ECDSA"
   private_key_pem = tls_private_key.thanos-tls-querier-cert-key[each.key].private_key_pem
 
   subject {
@@ -150,7 +149,6 @@ resource "tls_cert_request" "thanos-tls-querier-cert-csr" {
 resource "tls_locally_signed_cert" "thanos-tls-querier-cert" {
   for_each           = { for k, v in local.thanos-tls-querier : k => v if v["enabled"] && v["generate_cert"] }
   cert_request_pem   = tls_cert_request.thanos-tls-querier-cert-csr[each.key].cert_request_pem
-  ca_key_algorithm   = "ECDSA"
   ca_private_key_pem = tls_private_key.thanos-tls-querier-ca-key[0].private_key_pem
   ca_cert_pem        = tls_self_signed_cert.thanos-tls-querier-ca-cert[0].cert_pem
 

--- a/modules/aws/thanos.tf
+++ b/modules/aws/thanos.tf
@@ -347,7 +347,6 @@ resource "tls_private_key" "thanos-tls-querier-ca-key" {
 
 resource "tls_self_signed_cert" "thanos-tls-querier-ca-cert" {
   count             = local.thanos["generate_ca"] ? 1 : 0
-  key_algorithm     = "ECDSA"
   private_key_pem   = tls_private_key.thanos-tls-querier-ca-key[0].private_key_pem
   is_ca_certificate = true
 

--- a/modules/aws/vault.tf
+++ b/modules/aws/vault.tf
@@ -264,7 +264,6 @@ resource "tls_private_key" "vault-tls-ca-key" {
 
 resource "tls_self_signed_cert" "vault-tls-ca-cert" {
   count             = local.vault["generate_ca"] ? 1 : 0
-  key_algorithm     = "ECDSA"
   private_key_pem   = tls_private_key.vault-tls-ca-key[0].private_key_pem
   is_ca_certificate = true
 
@@ -288,7 +287,6 @@ resource "tls_private_key" "vault-tls-client-key" {
 
 resource "tls_cert_request" "vault-tls-client-csr" {
   count           = local.vault["generate_ca"] ? 1 : 0
-  key_algorithm   = "ECDSA"
   private_key_pem = tls_private_key.vault-tls-client-key[count.index].private_key_pem
 
   subject {
@@ -303,7 +301,6 @@ resource "tls_cert_request" "vault-tls-client-csr" {
 resource "tls_locally_signed_cert" "vault-tls-client-cert" {
   count              = local.vault["generate_ca"] ? 1 : 0
   cert_request_pem   = tls_cert_request.vault-tls-client-csr[count.index].cert_request_pem
-  ca_key_algorithm   = "ECDSA"
   ca_private_key_pem = tls_private_key.vault-tls-ca-key[count.index].private_key_pem
   ca_cert_pem        = tls_self_signed_cert.vault-tls-ca-cert[count.index].cert_pem
 

--- a/modules/aws/versions.tf
+++ b/modules/aws/versions.tf
@@ -18,7 +18,7 @@ terraform {
     }
     tls = {
       source  = "hashicorp/tls"
-      version = "~> 3.0"
+      version = "~> 4.0"
     }
   }
 }

--- a/modules/azure/README.md
+++ b/modules/azure/README.md
@@ -14,7 +14,7 @@ Provides various Kubernetes addons that are often used on Kubernetes with Azure
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0 |
 | <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | ~> 1.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0, != 2.12 |
-| <a name="requirement_tls"></a> [tls](#requirement\_tls) | ~> 3.0 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | ~> 4.0 |
 
 ## Providers
 
@@ -28,7 +28,7 @@ Provides various Kubernetes addons that are often used on Kubernetes with Azure
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | ~> 2.0, != 2.12 |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
 | <a name="provider_time"></a> [time](#provider\_time) | n/a |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 3.0 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 4.0 |
 
 ## Modules
 

--- a/modules/azure/version.tf
+++ b/modules/azure/version.tf
@@ -18,7 +18,7 @@ terraform {
     }
     tls = {
       source  = "hashicorp/tls"
-      version = "~> 3.0"
+      version = "~> 4.0"
     }
   }
 }

--- a/modules/scaleway/README.md
+++ b/modules/scaleway/README.md
@@ -26,7 +26,7 @@ User guides, feature documentation and examples are available [here](https://git
 | <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | ~> 1.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0, != 2.12 |
 | <a name="requirement_scaleway"></a> [scaleway](#requirement\_scaleway) | >= 2.2.0 |
-| <a name="requirement_tls"></a> [tls](#requirement\_tls) | ~> 3.0 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | ~> 4.0 |
 
 ## Providers
 
@@ -41,7 +41,7 @@ User guides, feature documentation and examples are available [here](https://git
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
 | <a name="provider_scaleway"></a> [scaleway](#provider\_scaleway) | >= 2.2.0 |
 | <a name="provider_time"></a> [time](#provider\_time) | n/a |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 3.0 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 4.0 |
 
 ## Modules
 

--- a/modules/scaleway/loki-stack.tf
+++ b/modules/scaleway/loki-stack.tf
@@ -130,7 +130,6 @@ resource "tls_private_key" "loki-stack-ca-key" {
 
 resource "tls_self_signed_cert" "loki-stack-ca-cert" {
   count             = local.loki-stack["enabled"] && local.loki-stack["generate_ca"] ? 1 : 0
-  key_algorithm     = "ECDSA"
   private_key_pem   = tls_private_key.loki-stack-ca-key[0].private_key_pem
   is_ca_certificate = true
 
@@ -239,7 +238,6 @@ resource "tls_private_key" "promtail-key" {
 
 resource "tls_cert_request" "promtail-csr" {
   count           = local.loki-stack["enabled"] && local.loki-stack["generate_ca"] && local.loki-stack["create_promtail_cert"] ? 1 : 0
-  key_algorithm   = "ECDSA"
   private_key_pem = tls_private_key.promtail-key[count.index].private_key_pem
 
   subject {
@@ -254,7 +252,6 @@ resource "tls_cert_request" "promtail-csr" {
 resource "tls_locally_signed_cert" "promtail-cert" {
   count              = local.loki-stack["enabled"] && local.loki-stack["generate_ca"] && local.loki-stack["create_promtail_cert"] ? 1 : 0
   cert_request_pem   = tls_cert_request.promtail-csr[count.index].cert_request_pem
-  ca_key_algorithm   = "ECDSA"
   ca_private_key_pem = tls_private_key.loki-stack-ca-key[count.index].private_key_pem
   ca_cert_pem        = tls_self_signed_cert.loki-stack-ca-cert[count.index].cert_pem
 

--- a/modules/scaleway/thanos-tls-querier.tf
+++ b/modules/scaleway/thanos-tls-querier.tf
@@ -135,7 +135,6 @@ resource "tls_private_key" "thanos-tls-querier-cert-key" {
 
 resource "tls_cert_request" "thanos-tls-querier-cert-csr" {
   for_each        = { for k, v in local.thanos-tls-querier : k => v if v["enabled"] && v["generate_cert"] }
-  key_algorithm   = "ECDSA"
   private_key_pem = tls_private_key.thanos-tls-querier-cert-key[each.key].private_key_pem
 
   subject {
@@ -150,7 +149,6 @@ resource "tls_cert_request" "thanos-tls-querier-cert-csr" {
 resource "tls_locally_signed_cert" "thanos-tls-querier-cert" {
   for_each           = { for k, v in local.thanos-tls-querier : k => v if v["enabled"] && v["generate_cert"] }
   cert_request_pem   = tls_cert_request.thanos-tls-querier-cert-csr[each.key].cert_request_pem
-  ca_key_algorithm   = "ECDSA"
   ca_private_key_pem = tls_private_key.thanos-tls-querier-ca-key[0].private_key_pem
   ca_cert_pem        = tls_self_signed_cert.thanos-tls-querier-ca-cert[0].cert_pem
 

--- a/modules/scaleway/thanos.tf
+++ b/modules/scaleway/thanos.tf
@@ -272,7 +272,6 @@ resource "tls_private_key" "thanos-tls-querier-ca-key" {
 
 resource "tls_self_signed_cert" "thanos-tls-querier-ca-cert" {
   count             = local.thanos["generate_ca"] ? 1 : 0
-  key_algorithm     = "ECDSA"
   private_key_pem   = tls_private_key.thanos-tls-querier-ca-key[0].private_key_pem
   is_ca_certificate = true
 

--- a/modules/scaleway/versions.tf
+++ b/modules/scaleway/versions.tf
@@ -21,7 +21,7 @@ terraform {
     }
     tls = {
       source  = "hashicorp/tls"
-      version = "~> 3.0"
+      version = "~> 4.0"
     }
   }
 }

--- a/vault.tf
+++ b/vault.tf
@@ -152,7 +152,6 @@ resource "tls_private_key" "vault-tls-ca-key" {
 
 resource "tls_self_signed_cert" "vault-tls-ca-cert" {
   count             = local.vault["generate_ca"] ? 1 : 0
-  key_algorithm     = "ECDSA"
   private_key_pem   = tls_private_key.vault-tls-ca-key[0].private_key_pem
   is_ca_certificate = true
 
@@ -176,7 +175,6 @@ resource "tls_private_key" "vault-tls-client-key" {
 
 resource "tls_cert_request" "vault-tls-client-csr" {
   count           = local.vault["generate_ca"] ? 1 : 0
-  key_algorithm   = "ECDSA"
   private_key_pem = tls_private_key.vault-tls-client-key[count.index].private_key_pem
 
   subject {
@@ -191,7 +189,6 @@ resource "tls_cert_request" "vault-tls-client-csr" {
 resource "tls_locally_signed_cert" "vault-tls-client-cert" {
   count              = local.vault["generate_ca"] ? 1 : 0
   cert_request_pem   = tls_cert_request.vault-tls-client-csr[count.index].cert_request_pem
-  ca_key_algorithm   = "ECDSA"
   ca_private_key_pem = tls_private_key.vault-tls-ca-key[count.index].private_key_pem
   ca_cert_pem        = tls_self_signed_cert.vault-tls-ca-cert[count.index].cert_pem
 

--- a/versions.tf
+++ b/versions.tf
@@ -17,7 +17,7 @@ terraform {
     }
     tls = {
       source  = "hashicorp/tls"
-      version = "~> 3.0"
+      version = "~> 4.0"
     }
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: upgrade default TLS provider to v4 and remove
deprecated field. Should work without manual changes

Signed-off-by: Kevin Lefevre <kevin@particule.io>

# Pull request title

## Description

Please explain the changes you made here and link to any relevant issues.

### Checklist

- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/particuleio/terraform-kubernetes-addons/#doc-generation
