### PR TITLE
Allow aws-lb-controller namespace var to be overwritten

### DIFF
--- a/modules/aws/aws-load-balancer-controller.tf
+++ b/modules/aws/aws-load-balancer-controller.tf
@@ -6,7 +6,7 @@ locals {
       chart                     = local.helm_dependencies[index(local.helm_dependencies.*.name, "aws-load-balancer-controller")].name
       repository                = local.helm_dependencies[index(local.helm_dependencies.*.name, "aws-load-balancer-controller")].repository
       chart_version             = local.helm_dependencies[index(local.helm_dependencies.*.name, "aws-load-balancer-controller")].version
-      namespace                 = "aws-load-balancer-controller"
+      namespace                 = local.aws-load-balancer-controller["namespace"] ? "aws-load-balancer-controller" : local.aws-load-balancer-controller["namespace"]
       service_account_name      = "aws-load-balancer-controller"
       create_iam_resources_irsa = true
       enabled                   = false


### PR DESCRIPTION
# Allow aws-lb-controller namespace var to be overwritten

## Description

Allows aws-load-balancer-controller namespace to be configurable, and still sets default namespace as `aws-load-balancer-controller`

This enables us to deploy it in specific namespace, my use case is `istio-system` to leverage the aws-load-balancer-tls that gets created for us for the ingress and istio-gateway.

@ArchiFleKs 

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/particuleio/terraform-kubernetes-addons/#doc-generation