### PR TITLE
fix(aws): Adding missing policy for cluster-autoscaler

### DIFF
--- a/modules/aws/cluster-autoscaler.tf
+++ b/modules/aws/cluster-autoscaler.tf
@@ -77,6 +77,7 @@ data "aws_iam_policy_document" "cluster-autoscaler" {
       "autoscaling:DescribeAutoScalingInstances",
       "autoscaling:DescribeLaunchConfigurations",
       "autoscaling:DescribeTags",
+      "ec2:DescribeInstanceTypes",
       "ec2:DescribeLaunchTemplateVersions",
     ]
 


### PR DESCRIPTION
# Adding missing policy for cluster-autoscaler

## Description

Error I received:
```
Failed to generate AWS EC2 Instance Types: UnauthorizedOperation: You are not authorized to perform this operation.
```

These changes were made because when I run cluster-autoscaler on China, it was in a crashloopback. Once I added the missing policy, it spun up successfully and started running.

https://github.com/kubernetes/autoscaler/issues/3216#issuecomment-644038135

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/particuleio/terraform-kubernetes-addons/#doc-generation
