### PR TITLE
feat(charts): prepare AWS ECR containers images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .terragrunt-cache
 .terraform
 .terraform.lock.hcl
+*.tfstate*

--- a/README.md
+++ b/README.md
@@ -93,12 +93,14 @@ here](https://github.com/particuleio/terraform-kubernetes-addons/blob/master/.gi
 | <a name="requirement_http"></a> [http](#requirement\_http) | >= 3 |
 | <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | ~> 1.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0, != 2.12 |
+| <a name="requirement_skopeo"></a> [skopeo](#requirement\_skopeo) | 0.0.4 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | ~> 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 | <a name="provider_flux"></a> [flux](#provider\_flux) | ~> 0.19 |
 | <a name="provider_github"></a> [github](#provider\_github) | ~> 5.0 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | ~> 2.0 |
@@ -106,6 +108,7 @@ here](https://github.com/particuleio/terraform-kubernetes-addons/blob/master/.gi
 | <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | ~> 1.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | ~> 2.0, != 2.12 |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| <a name="provider_skopeo"></a> [skopeo](#provider\_skopeo) | 0.0.4 |
 | <a name="provider_time"></a> [time](#provider\_time) | n/a |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 4.0 |
 
@@ -117,6 +120,7 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [aws_ecr_repository.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) | resource |
 | [github_branch_default.main](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/branch_default) | resource |
 | [github_repository.main](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository) | resource |
 | [github_repository_deploy_key.main](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_deploy_key) | resource |
@@ -282,6 +286,7 @@ No modules.
 | [kubernetes_secret.vault-ca](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [kubernetes_secret.webhook_issuer_tls](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [random_string.grafana_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
+| [skopeo_copy.this](https://registry.terraform.io/providers/abergmeier/skopeo/0.0.4/docs/resources/copy) | resource |
 | [time_sleep.cert-manager_sleep](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [tls_cert_request.promtail-csr](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/cert_request) | resource |
 | [tls_cert_request.vault-tls-client-csr](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/cert_request) | resource |
@@ -321,6 +326,11 @@ No modules.
 | <a name="input_cluster-autoscaler"></a> [cluster-autoscaler](#input\_cluster-autoscaler) | Customize cluster-autoscaler chart, see `cluster-autoscaler.tf` for supported values | `any` | `{}` | no |
 | <a name="input_cluster-name"></a> [cluster-name](#input\_cluster-name) | Name of the Kubernetes cluster | `string` | `"sample-cluster"` | no |
 | <a name="input_csi-external-snapshotter"></a> [csi-external-snapshotter](#input\_csi-external-snapshotter) | Customize csi-external-snapshotter, see `csi-external-snapshotter.tf` for supported values | `any` | `{}` | no |
+| <a name="input_ecr_encryption_type"></a> [ecr\_encryption\_type](#input\_ecr\_encryption\_type) | Encryption type for ECR images | `string` | `"AES256"` | no |
+| <a name="input_ecr_immutable_tag"></a> [ecr\_immutable\_tag](#input\_ecr\_immutable\_tag) | Use immutable tags for ECR images | `bool` | `false` | no |
+| <a name="input_ecr_kms_key"></a> [ecr\_kms\_key](#input\_ecr\_kms\_key) | Preconfigured KMS key arn to encrypt ECR images | `any` | `null` | no |
+| <a name="input_ecr_prepare_images"></a> [ecr\_prepare\_images](#input\_ecr\_prepare\_images) | Prepare containers images for addons and store it in ECR | `bool` | `false` | no |
+| <a name="input_ecr_scan_on_push"></a> [ecr\_scan\_on\_push](#input\_ecr\_scan\_on\_push) | Scan prepared ECR images on push | `bool` | `false` | no |
 | <a name="input_external-dns"></a> [external-dns](#input\_external-dns) | Map of map for external-dns configuration: see `external_dns.tf` for supported values | `any` | `{}` | no |
 | <a name="input_flux"></a> [flux](#input\_flux) | Customize Flux chart, see `flux.tf` for supported values | `any` | `{}` | no |
 | <a name="input_flux2"></a> [flux2](#input\_flux2) | Customize Flux chart, see `flux2.tf` for supported values | `any` | `{}` | no |

--- a/aws-prepare-images.tf
+++ b/aws-prepare-images.tf
@@ -1,0 +1,1 @@
+modules/aws/aws-prepare-images.tf

--- a/helm-dependencies.yaml
+++ b/helm-dependencies.yaml
@@ -1,3 +1,75 @@
+# NOTE: Each dependency may have containers data to prepare images for use in private
+# EKS clusters. Skopeo will copy images from the given source/registry into ensured ECR.
+# There are source/registry paths used to overwrite for helm and/or to prepared images.
+# It also can provide helm values override paths for image/tag data. For addons not
+# managed with helm_release, but kubectl_manifest, you can still provide containers data.
+#
+# Example:
+# - name: foo-addon-charts
+#   containers:
+#     # This results in custom.io/prod/foo:v1.1 copied as <ECR repo>/foo:v1.1,
+#     # then its helm values updated via the 'helm set' interface
+#     app.foo.spec.containers.frontend:
+#       name:
+#         uri: foo # sets image for helm as app.foo.spec.containers.frontend.uri
+#       ver:
+#         # use 'skopeo list-tags' to pick the best value from available tags
+#         version: v1.1 # sets tag for helm as app.foo.spec.containers.frontend.version
+#
+#       # Optional ECR settings (not for helm), override the addons module vars
+#       ecr_immutable_tag: false
+#       ecr_scan_on_push: false
+#       ecr_encryption_type: KMS
+#       ecr_kms_key: my-kms-key
+#
+#       # Either to prepare images in ECR, or just override the helm values.
+#       # Disabling it makes the 'source' data ignored. The name/registry values
+#       # then end up in helm as provided (i.e. no paths rewriting for ECR)
+#       ecr_prepare_images: true
+#
+#       # Assumes the 'name' holds a shortname instead of URI.
+#       # When 'source' is unset, skopeo_copy takes this as a source, and ECR as a dst.
+#       # Helm takes the prepared ECR repo URL value, or the original value, if
+#       # 'ecr_prepare_images' was disabled.
+#       registry:
+#         # sets registry for helm as app.foo.spec.containers.frontend.repository,
+#         # based on ecr_prepare_images enabled, or not
+#         repository: custom.io/prod # used as a source only, or as a final value
+#
+#       # Ignored when ecr_prepare_images is off.
+#       # Use this instead of 'registry', if image name is URI and already includes the
+#       # registry path. Then the registry path in the name will get overwritten by the
+#       # prepared ECR repositroy replacing the source value of it.
+#       # NOTE: to rewrite helm 'source' value, define it as {registry: {source: ...}}
+#       source: custom.io/prod  # cannot end with a slash /
+#
+#     extra.image:
+#       # Has ecr_prepare_images enabled by default
+#       name:
+#         # NOTE: the registry path part of URI must be the same as in the source, e.g.:
+#         # custom.io, or custom.io/dev (ambiguous names might require the former notation)
+#         image_uri: custom.io/dev/baz # Helm takes prepared <ECR>/dev/baz:latest
+#       source: custom.io  # skopeo copies it from custom.io/dev/baz:latest to ECR
+#
+#     sidecar.spec.containers:
+#       # Helm will use custom.io/dev/qux:<whatever tag it defines>
+#       ecr_prepare_images: false
+#       name:
+#         image: dev/qux # sets image for helm as sidecar.spec.containers.image
+#       registry: # sets helm to use sidecar.spec.containers.source registry as provided
+#         source: custom.io
+#       source: custom.io/prod  # will be ignored as ecr_prepare_images is off!
+#
+#      bad.example:
+#        # 'registry' will be ignored when preparing images,
+#        # but helm will take both rewritten registry and uri paths,
+#        # which might result in a misconfigured chart (repo info looks redundant here)
+#        name:
+#          uri: custom.io/quux:v123  # helm takes <ECR>/quux:v123
+#        registry:
+#          repo: custom.io/prod      # helm takes <ECR>/prod?..
+#        source: custom.io
+#
 apiVersion: v2
 name: Handle terraform-kubernetes-addons helm chart dependencies update
 version: 1.0.0
@@ -8,42 +80,191 @@ dependencies:
   - name: secrets-store-csi-driver
     version: 1.2.4
     repository: https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts
+  # https://github.dev/kubernetes-sigs/aws-ebs-csi-driver/blob/master/charts/aws-ebs-csi-driver/values.yaml
   - name: aws-ebs-csi-driver
     version: 2.11.1
     repository: https://kubernetes-sigs.github.io/aws-ebs-csi-driver
+    containers:
+      image:
+        name:
+          repository: docker.io/amazon/aws-ebs-csi-driver
+        ver:
+          tag: v1.6.2
+        source: docker.io/amazon
+      sidecars.provisioner.image:
+        name:
+          repository: k8s.gcr.io/sig-storage/csi-provisioner
+        ver:
+          tag: v3.1.0
+        source: k8s.gcr.io/sig-storage
+      sidecars.attacher.image:
+        name:
+          repository: k8s.gcr.io/sig-storage/csi-attacher
+        ver:
+          tag: v3.4.0
+        source: k8s.gcr.io/sig-storage
+      sidecars.snapshotter.image:
+        name:
+          repository: k8s.gcr.io/sig-storage/csi-snapshotter
+        ver:
+          tag: v6.0.1
+        source: k8s.gcr.io/sig-storage
+      sidecars.livenessProbe.image:
+        name:
+          repository: k8s.gcr.io/sig-storage/livenessprobe
+        ver:
+          tag: v2.6.0
+        source: k8s.gcr.io  # livenessprobe is ambigouse, so leave sig-storage prefix not rewritten
+      sidecars.resizer.image:
+        name:
+          repository: k8s.gcr.io/sig-storage/csi-resizer
+        ver:
+          tag: v1.4.0
+        source: k8s.gcr.io/sig-storage
+      sidecars.nodeDriverRegistrar.image:
+        name:
+          repository: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+        ver:
+          tag: v2.5.1
+        source: k8s.gcr.io/sig-storage
+      sidecars.csiProvisioner.image:
+        name:
+          repository: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
+        ver:
+          tag: v2.1.1-eks-1-18-13
+        source: public.ecr.aws/eks-distro
+  # https://github.dev/kubernetes-sigs/aws-efs-csi-driver/blob/master/charts/aws-efs-csi-driver/values.yaml
   - name: aws-efs-csi-driver
     version: 2.2.8
     repository: https://kubernetes-sigs.github.io/aws-efs-csi-driver
+    containers:
+      image:
+        name:
+          repository: docker.io/amazon/aws-efs-csi-driver
+        ver:
+          tag: v1.4.1
+        source: docker.io/amazon
+      sidecars.livenessProbe.image:
+        name:
+          repository: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
+        ver:
+          tag: v2.2.0-eks-1-18-13
+        source: public.ecr.aws/eks-distro
+      sidecars.nodeDriverRegistrar.image:
+        name:
+          repository: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
+        ver:
+          tag: v2.1.0-eks-1-18-13
+        source: public.ecr.aws/eks-distro
+      sidecars.csiProvisioner.image:
+        name:
+          repository: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
+        ver:
+          tag: v2.1.1-eks-1-18-13
+        source: public.ecr.aws/eks-distro
   - name: aws-for-fluent-bit
     version: 0.1.21
     repository: https://aws.github.io/eks-charts
+  # https://github.dev/kubernetes-sigs/aws-load-balancer-controller/blob/main/helm/aws-load-balancer-controller/values.yaml
   - name: aws-load-balancer-controller
     version: 1.4.5
     repository: https://aws.github.io/eks-charts
+    containers:
+      image:
+        name:
+          repository: docker.io/amazon/aws-alb-ingress-controller
+        ver:
+          tag: v2.4.3
+        source: docker.io/amazon
   - name: aws-node-termination-handler
     version: 0.19.3
     repository: https://aws.github.io/eks-charts
   - name: aws-calico
     version: 0.3.11
     repository: https://aws.github.io/eks-charts
+  # https://github.dev/cert-manager/cert-manager/blob/master/deploy/charts/cert-manager/values.yaml
   - name: cert-manager
     version: v1.9.1
     repository: https://charts.jetstack.io
+    containers:
+      image:
+        name:
+          repository: quay.io/jetstack/cert-manager-controller
+        ver:
+          tag: v1.9.1
+        source: quay.io/jetstack
+      webhook.image:
+        name:
+          repository: quay.io/jetstack/cert-manager-webhook
+        ver:
+          tag: v1.9.1
+        source: quay.io/jetstack
+      cainjector.image:
+        name:
+          repository: quay.io/jetstack/cert-manager-cainjector
+        ver:
+          tag: v1.9.1
+        source: quay.io/jetstack
+      startupapicheck.image:
+        name:
+          repository: quay.io/jetstack/cert-manager-ctl
+        ver:
+          tag: v1.9.1
+        source: quay.io/jetstack
   - name: cert-manager-csi-driver
     version: v0.4.2
     repository: https://charts.jetstack.io
+  # https://github.dev/kubernetes/autoscaler/blob/master/charts/cluster-autoscaler/values.yaml
   - name: cluster-autoscaler
     version: 9.21.0
     repository: https://kubernetes.github.io/autoscaler
+    containers:
+      image:
+        name:
+          repository: k8s.gcr.io/autoscaling/cluster-autoscaler
+        ver:
+          tag: v1.24.0
+        source: k8s.gcr.io/autoscaling
+  # https://github.dev/kubernetes-sigs/external-dns/blob/master/charts/external-dns/values.yaml
   - name: external-dns
     version: 1.11.0
     repository: https://kubernetes-sigs.github.io/external-dns/
+    containers:
+      image:
+        name:
+          repository: k8s.gcr.io/external-dns/external-dns
+        ver:
+          tag: v0.12.2
+        source: k8s.gcr.io/external-dns
   - name: flux
     version: 1.13.3
     repository: https://charts.fluxcd.io
+  # https://github.dev/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
   - name: ingress-nginx
     version: 4.3.0
     repository: https://kubernetes.github.io/ingress-nginx
+    containers:
+      controller.admissionWebhooks.patch.image:
+        name:
+          image: ingress-nginx/kube-webhook-certgen
+        ver:
+          tag: v1.1.1 # poke v1.3.0?
+        registry:
+          registry: registry.k8s.io
+      defaultBackend.image:
+        name:
+          image: defaultbackend-amd64
+        ver:
+          tag: "1.5"
+        registry:
+          registry: registry.k8s.io
+      controller.image:
+        name:
+          image: ingress-nginx/controller
+        ver:
+          tag: v1.0.4
+        registry:
+          registry: registry.k8s.io
   - name: istio-operator
     version: 1.7.0
     repository: https://clusterfrak-dynamics.github.io/istio/
@@ -62,9 +283,89 @@ dependencies:
   - name: kong
     version: 2.13.1
     repository: https://charts.konghq.com
+  # https://github.dev/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml
   - name: kube-prometheus-stack
     version: 40.3.1
     repository: https://prometheus-community.github.io/helm-charts
+    containers:
+      prometheus-node-exporter.image:
+        name:
+          repository: quay.io/prometheus/node-exporter
+        ver:
+          tag: v1.3.1
+        source: quay.io/prometheus
+      kube-state-metrics.image:
+        name:
+          repository: registry.k8s.io/kube-state-metrics/kube-state-metrics
+        ver:
+          tag: v2.5.0
+        source: registry.k8s.io/kube-state-metrics
+      alertmanager.alertmanagerSpec.image:
+        name:
+          repository: quay.io/prometheus/alertmanager
+        ver:
+          tag: v0.24.0
+        source: quay.io/prometheus
+      prometheusOperator.admissionWebhooks.patch.image:
+        name:
+          repository: k8s.gcr.io/ingress-nginx/kube-webhook-certgen
+        ver:
+          tag: v1.2.0  # poke v1.3.0?
+        source: k8s.gcr.io/ingress-nginx
+      prometheusOperator.image:
+        name:
+          repository: quay.io/prometheus-operator/prometheus-operator
+        ver:
+          tag: v0.58.0
+        source: quay.io/prometheus-operator
+      prometheusOperator.prometheusConfigReloader.image:
+        name:
+          repository: quay.io/prometheus-operator/prometheus-config-reloader
+        ver:
+          tag: v0.58.0
+        source: quay.io/prometheus-operator
+      prometheusOperator.thanosImage: &thanos
+        name:
+          repository: quay.io/thanos/thanos
+        ver:
+          tag: v0.27.0
+        source: quay.io/thanos
+      prometheus.prometheusSpec.image:
+        name:
+          repository: quay.io/prometheus/prometheus
+        ver:
+          tag: v2.37.0
+        source: quay.io/prometheus
+      thanosRuler.thanosRulerSpec.image: *thanos
+      # https://github.dev/grafana/helm-charts/blob/main/charts/grafana/values.yaml
+      grafana.image:
+        name:
+          repository: docker.io/grafana/grafana
+        ver:
+          tag: 9.1.0
+        source: docker.io/grafana
+      grafana.downloadDashboardsImage:
+        name:
+          repository: docker.io/curlimages/curl
+        ver:
+          tag: 7.73.0 # poke 7.84.0?
+        source: docker.io
+      grafana.initChownData.image:
+        name:
+          repository: docker.io/busybox
+        ver:
+          tag: 1.31.1
+        source: docker.io
+      grafana.sidecar.image:
+        name:
+          repository: quay.io/kiwigrid/k8s-sidecar
+        ver:
+          tag: 1.19.2
+        source: quay.io
+      grafana.imageRenderer.image:
+        name:
+          repository: docker.io/grafana/grafana-image-renderer
+        source: docker.io/grafana
   - name: kyverno
     version: v2.5.3
     repository: https://kyverno.github.io/kyverno/
@@ -89,12 +390,28 @@ dependencies:
   - name: promtail
     version: 6.4.0
     repository: https://grafana.github.io/helm-charts
+  # https://github.dev/kubernetes-sigs/metrics-server/blob/master/charts/metrics-server/values.yaml
   - name: metrics-server
     version: 3.8.2
     repository: https://kubernetes-sigs.github.io/metrics-server/
+    containers:
+      image:
+        name:
+          repository: k8s.gcr.io/metrics-server/metrics-server
+        ver:
+          tag: v0.6.1
+        source: k8s.gcr.io/metrics-server
+  # https://github.dev/deliveryhero/helm-charts/blob/master/stable/node-problem-detector/values.yaml
   - name: node-problem-detector
     version: 2.2.6
     repository: https://charts.deliveryhero.io/
+    containers:
+      image:
+        name:
+          repository: k8s.gcr.io/node-problem-detector/node-problem-detector
+        ver:
+          tag: v0.8.10
+        source: k8s.gcr.io/node-problem-detector
   - name: prometheus-adapter
     version: 3.4.0
     repository: https://prometheus-community.github.io/helm-charts
@@ -119,9 +436,24 @@ dependencies:
   - name: thanos
     version: 11.5.3
     repository: https://charts.bitnami.com/bitnami
+  # https://github.dev/projectcalico/calico/blob/master/charts/tigera-operator/values.yaml
   - name: tigera-operator
     version: v3.24.1
     repository: https://docs.projectcalico.org/charts
+    containers:
+      tigeraOperator:
+        name:
+          image: tigera/operator
+        ver:
+          version: master
+        registry:
+          registry: quay.io
+      calicoctl:
+        name:
+          image: docker.io/calico/ctl
+        ver:
+          tag: master
+        source: docker.io # ctl is ambiguose, leave calico prefix in ECR repo url
   - name: traefik
     version: 10.30.1
     repository: https://helm.traefik.io/traefik

--- a/metrics-server.tf
+++ b/metrics-server.tf
@@ -59,7 +59,54 @@ resource "helm_release" "metrics-server" {
     local.values_metrics-server,
     local.metrics-server["extra_values"]
   ]
+
+  #TODO(bogdando): create a shared template and refer it in addons (copy-pasta until then)
+  dynamic "set" {
+    for_each = {
+      for c, v in local.images_data.metrics-server.containers :
+      c => v if v.rewrite_values.tag != null
+    }
+    content {
+      name  = set.value.rewrite_values.tag.name
+      value = try(local.metrics-server["containers_versions"][set.value.rewrite_values.tag.name], set.value.rewrite_values.tag.value)
+    }
+  }
+  dynamic "set" {
+    for_each = local.images_data.metrics-server.containers
+    content {
+      name = set.value.rewrite_values.image.name
+      value = set.value.ecr_prepare_images && set.value.source_provided ? "${
+        aws_ecr_repository.this[
+          format("%s.%s", split(".", set.key)[0], split(".", set.key)[2])
+        ].repository_url}${set.value.rewrite_values.image.tail
+        }" : set.value.ecr_prepare_images ? "${
+        aws_ecr_repository.this[
+          format("%s.%s", split(".", set.key)[0], split(".", set.key)[2])
+        ].name
+      }" : set.value.rewrite_values.image.value
+    }
+  }
+  dynamic "set" {
+    for_each = {
+      for c, v in local.images_data.metrics-server.containers :
+      c => v if v.rewrite_values.registry != null
+    }
+    content {
+      name = set.value.rewrite_values.registry.name
+      # when unset, it should be replaced with the one prepared on ECR
+      value = set.value.rewrite_values.registry.value != null ? set.value.rewrite_values.registry.value : split(
+        "/", aws_ecr_repository.this[
+          format("%s.%s", split(".", set.key)[0], split(".", set.key)[2])
+        ].repository_url
+      )[0]
+    }
+  }
+
   namespace = kubernetes_namespace.metrics-server.*.metadata.0.name[count.index]
+
+  depends_on = [
+    skopeo_copy.this
+  ]
 }
 
 resource "kubernetes_network_policy" "metrics-server_default_deny" {

--- a/modules/aws/README.md
+++ b/modules/aws/README.md
@@ -28,6 +28,7 @@ This module can uses [IRSA](https://aws.amazon.com/blogs/opensource/introducing-
 | <a name="requirement_http"></a> [http](#requirement\_http) | >= 3 |
 | <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | ~> 1.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0, != 2.12 |
+| <a name="requirement_skopeo"></a> [skopeo](#requirement\_skopeo) | 0.0.4 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | ~> 4.0 |
 
 ## Providers
@@ -42,6 +43,7 @@ This module can uses [IRSA](https://aws.amazon.com/blogs/opensource/introducing-
 | <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | ~> 1.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | ~> 2.0, != 2.12 |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| <a name="provider_skopeo"></a> [skopeo](#provider\_skopeo) | 0.0.4 |
 | <a name="provider_time"></a> [time](#provider\_time) | n/a |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 4.0 |
 
@@ -76,6 +78,7 @@ This module can uses [IRSA](https://aws.amazon.com/blogs/opensource/introducing-
 | Name | Type |
 |------|------|
 | [aws_cloudwatch_log_group.aws-for-fluent-bit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_ecr_repository.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) | resource |
 | [aws_efs_file_system.aws-efs-csi-driver](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_file_system) | resource |
 | [aws_efs_mount_target.aws-efs-csi-driver](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_mount_target) | resource |
 | [aws_iam_policy.aws-ebs-csi-driver](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
@@ -319,6 +322,7 @@ This module can uses [IRSA](https://aws.amazon.com/blogs/opensource/introducing-
 | [kubernetes_storage_class.aws-ebs-csi-driver](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/storage_class) | resource |
 | [kubernetes_storage_class.aws-efs-csi-driver](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/storage_class) | resource |
 | [random_string.grafana_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
+| [skopeo_copy.this](https://registry.terraform.io/providers/abergmeier/skopeo/0.0.4/docs/resources/copy) | resource |
 | [time_sleep.cert-manager_sleep](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [tls_cert_request.promtail-csr](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/cert_request) | resource |
 | [tls_cert_request.thanos-tls-querier-cert-csr](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/cert_request) | resource |
@@ -397,6 +401,11 @@ This module can uses [IRSA](https://aws.amazon.com/blogs/opensource/introducing-
 | <a name="input_cluster-name"></a> [cluster-name](#input\_cluster-name) | Name of the Kubernetes cluster | `string` | `"sample-cluster"` | no |
 | <a name="input_cni-metrics-helper"></a> [cni-metrics-helper](#input\_cni-metrics-helper) | Customize cni-metrics-helper deployment, see `cni-metrics-helper.tf` for supported values | `any` | `{}` | no |
 | <a name="input_csi-external-snapshotter"></a> [csi-external-snapshotter](#input\_csi-external-snapshotter) | Customize csi-external-snapshotter, see `csi-external-snapshotter.tf` for supported values | `any` | `{}` | no |
+| <a name="input_ecr_encryption_type"></a> [ecr\_encryption\_type](#input\_ecr\_encryption\_type) | Encryption type for ECR images | `string` | `"AES256"` | no |
+| <a name="input_ecr_immutable_tag"></a> [ecr\_immutable\_tag](#input\_ecr\_immutable\_tag) | Use immutable tags for ECR images | `bool` | `false` | no |
+| <a name="input_ecr_kms_key"></a> [ecr\_kms\_key](#input\_ecr\_kms\_key) | Preconfigured KMS key arn to encrypt ECR images | `any` | `null` | no |
+| <a name="input_ecr_prepare_images"></a> [ecr\_prepare\_images](#input\_ecr\_prepare\_images) | Prepare containers images for addons and store it in ECR | `bool` | `false` | no |
+| <a name="input_ecr_scan_on_push"></a> [ecr\_scan\_on\_push](#input\_ecr\_scan\_on\_push) | Scan prepared ECR images on push | `bool` | `false` | no |
 | <a name="input_eks"></a> [eks](#input\_eks) | EKS cluster inputs | `any` | `{}` | no |
 | <a name="input_external-dns"></a> [external-dns](#input\_external-dns) | Map of map for external-dns configuration: see `external_dns.tf` for supported values | `any` | `{}` | no |
 | <a name="input_flux"></a> [flux](#input\_flux) | Customize Flux chart, see `flux.tf` for supported values | `any` | `{}` | no |

--- a/modules/aws/aws-ebs-csi-driver.tf
+++ b/modules/aws/aws-ebs-csi-driver.tf
@@ -136,10 +136,54 @@ resource "helm_release" "aws-ebs-csi-driver" {
     local.values_aws-ebs-csi-driver,
     local.aws-ebs-csi-driver["extra_values"]
   ]
+
+  #TODO(bogdando): create a shared template and refer it in addons (copy-pasta until then)
+  dynamic "set" {
+    for_each = {
+      for c, v in local.images_data.aws-ebs-csi-driver.containers :
+      c => v if v.rewrite_values.tag != null
+    }
+    content {
+      name  = set.value.rewrite_values.tag.name
+      value = try(local.aws-ebs-csi-driver["containers_versions"][set.value.rewrite_values.tag.name], set.value.rewrite_values.tag.value)
+    }
+  }
+  dynamic "set" {
+    for_each = local.images_data.aws-ebs-csi-driver.containers
+    content {
+      name = set.value.rewrite_values.image.name
+      value = set.value.ecr_prepare_images && set.value.source_provided ? "${
+        aws_ecr_repository.this[
+          format("%s.%s", split(".", set.key)[0], split(".", set.key)[2])
+        ].repository_url}${set.value.rewrite_values.image.tail
+        }" : set.value.ecr_prepare_images ? "${
+        aws_ecr_repository.this[
+          format("%s.%s", split(".", set.key)[0], split(".", set.key)[2])
+        ].name
+      }" : set.value.rewrite_values.image.value
+    }
+  }
+  dynamic "set" {
+    for_each = {
+      for c, v in local.images_data.aws-ebs-csi-driver.containers :
+      c => v if v.rewrite_values.registry != null
+    }
+    content {
+      name = set.value.rewrite_values.registry.name
+      # when unset, it should be replaced with the one prepared on ECR
+      value = set.value.rewrite_values.registry.value != null ? set.value.rewrite_values.registry.value : split(
+        "/", aws_ecr_repository.this[
+          format("%s.%s", split(".", set.key)[0], split(".", set.key)[2])
+        ].repository_url
+      )[0]
+    }
+  }
+
   namespace = local.aws-ebs-csi-driver["create_ns"] ? kubernetes_namespace.aws-ebs-csi-driver.*.metadata.0.name[count.index] : local.aws-ebs-csi-driver["namespace"]
 
   depends_on = [
-    kubectl_manifest.csi-external-snapshotter
+    kubectl_manifest.csi-external-snapshotter,
+    skopeo_copy.this
   ]
 }
 

--- a/modules/aws/aws-load-balancer-controller.tf
+++ b/modules/aws/aws-load-balancer-controller.tf
@@ -84,7 +84,54 @@ resource "helm_release" "aws-load-balancer-controller" {
     local.values_aws-load-balancer-controller,
     local.aws-load-balancer-controller["extra_values"]
   ]
+
+  #TODO(bogdando): create a shared template and refer it in addons (copy-pasta until then)
+  dynamic "set" {
+    for_each = {
+      for c, v in local.images_data.aws-load-balancer-controller.containers :
+      c => v if v.rewrite_values.tag != null
+    }
+    content {
+      name  = set.value.rewrite_values.tag.name
+      value = try(local.aws-load-balancer-controller["containers_versions"][set.value.rewrite_values.tag.name], set.value.rewrite_values.tag.value)
+    }
+  }
+  dynamic "set" {
+    for_each = local.images_data.aws-load-balancer-controller.containers
+    content {
+      name = set.value.rewrite_values.image.name
+      value = set.value.ecr_prepare_images && set.value.source_provided ? "${
+        aws_ecr_repository.this[
+          format("%s.%s", split(".", set.key)[0], split(".", set.key)[2])
+        ].repository_url}${set.value.rewrite_values.image.tail
+        }" : set.value.ecr_prepare_images ? "${
+        aws_ecr_repository.this[
+          format("%s.%s", split(".", set.key)[0], split(".", set.key)[2])
+        ].name
+      }" : set.value.rewrite_values.image.value
+    }
+  }
+  dynamic "set" {
+    for_each = {
+      for c, v in local.images_data.aws-load-balancer-controller.containers :
+      c => v if v.rewrite_values.registry != null
+    }
+    content {
+      name = set.value.rewrite_values.registry.name
+      # when unset, it should be replaced with the one prepared on ECR
+      value = set.value.rewrite_values.registry.value != null ? set.value.rewrite_values.registry.value : split(
+        "/", aws_ecr_repository.this[
+          format("%s.%s", split(".", set.key)[0], split(".", set.key)[2])
+        ].repository_url
+      )[0]
+    }
+  }
+
   namespace = kubernetes_namespace.aws-load-balancer-controller.*.metadata.0.name[count.index]
+
+  depends_on = [
+    skopeo_copy.this
+  ]
 }
 
 resource "kubernetes_network_policy" "aws-load-balancer-controller_default_deny" {

--- a/modules/aws/aws-prepare-images.tf
+++ b/modules/aws/aws-prepare-images.tf
@@ -1,0 +1,128 @@
+variable "ecr_prepare_images" {
+  description = "Prepare containers images for addons and store it in ECR"
+  default     = false
+}
+variable "ecr_immutable_tag" {
+  description = "Use immutable tags for ECR images"
+  default     = false
+}
+variable "ecr_scan_on_push" {
+  description = "Scan prepared ECR images on push"
+  default     = false
+}
+variable "ecr_encryption_type" {
+  description = "Encryption type for ECR images"
+  default     = "AES256"
+}
+variable "ecr_kms_key" {
+  description = "Preconfigured KMS key arn to encrypt ECR images"
+  default     = null
+}
+
+locals {
+  default_tag = {
+    tag = "latest"
+  }
+  # image data can inlcude registry and/or tag, which will be handled properly
+  images_data = {
+    for _, item in local.helm_dependencies :
+    item.name => {
+      # contains a list of {uniq_config_path => {src_reigstry:..., parsed_tag:..., ...}} entries
+      containers = {
+        # NOTE: becaue we cannot use uuid func (https://github.com/hashicorp/terraform/issues/30838),
+        # compose uniq keys with logical fields: <addon>.<helm_value>.<shortreponame>, like:
+        # ingress-nginx.controller_admissionWebhooks_patch_image_image.ingress-nginx/kube-webhook-certgen
+        # for images requested to be prepared in ECR, the last field goes into repo url as a repo name
+        for k, v in item.containers :
+        format("%s.%s.%s",
+          # we use "." as a logical field name separator, do not confuse it with dots in logical data fields
+          replace(item.name, ".", "_"),
+          replace("${k}_${keys(v.name)[0]}", ".", "_"),
+          # strip source-URI/tag off the images names
+          replace(
+            lookup(v, "source", null) == null ? v.name[keys(v.name)[0]] : replace(
+              v.name[keys(v.name)[0]], "${v.source}/", ""
+            ),
+            ":${try(v.ver, local.default_tag)[keys(try(v.ver, local.default_tag))[0]]}", ""
+          )
+          ) => {
+          ecr_prepare_images  = try(v.ecr_prepare_images, var.ecr_prepare_images)
+          src_reigstry        = try(v.source, v.registry[keys(v.registry)[0]])
+          parsed_tag          = try(v.ver, local.default_tag)[keys(try(v.ver, local.default_tag))[0]]
+          ecr_kms_key         = try(v.ecr_kms_key, var.ecr_kms_key)
+          ecr_encryption_type = try(v.ecr_encryption_type, var.ecr_encryption_type)
+          ecr_scan_on_push    = try(v.ecr_scan_on_push, var.ecr_scan_on_push)
+          ecr_immutable_tag   = try(v.ecr_immutable_tag, var.ecr_immutable_tag)
+          helm_managed        = lookup(item, "repository", null) != null
+          source_provided     = lookup(v, "source", null) != null
+          rewrite_values = {
+            # tag overrides - only set helm values for explicit tags, not the 'latest' fallback for unset tags
+            tag = lookup(v, "ver", null) == null ? null : {
+              name  = "${k}.${keys(v.ver)[0]}"
+              value = v.ver[keys(v.ver)[0]]
+            }
+            # NOTE: value=null when cannot rewrite registry/name's URI-source, until the prepared ECR repo url and name become known
+            image = {
+              name = "${k}.${keys(v.name)[0]}"
+              # when prepared a ECR repo, the name value always needs a rewrite
+              value = lookup(v, "ecr_prepare_images", true) ? null : v.name[keys(v.name)[0]]
+              tail = length(
+                split(
+                  ":", lookup(v, "source", null) == null ? v.name[keys(v.name)[0]] : replace(
+                  v.name[keys(v.name)[0]], "${v.source}/", "")
+                )
+              ) == 1 ? "" : ":${split(":", v.name[keys(v.name)[0]])[length(v.name[keys(v.name)[0]]) - 1]}"
+            }
+            registry = lookup(v, "registry", null) == null ? null : {
+              name  = "${k}.${keys(v.registry)[0]}"
+              value = lookup(v, "ecr_prepare_images", true) ? null : v.registry[keys(v.registry)[0]]
+            }
+          }
+          } if(
+          lookup(v, "name", null) != null &&
+          (lookup(v, "registry", null) != null || lookup(v, "source", null) != null)
+        )
+      }
+    } if(lookup(item, "containers", null) != null)
+  }
+
+  ecr_names = { for k, v in values(local.images_data)[*]["containers"] : k => keys(v) }
+  ecr_data  = { for k, v in values(local.images_data)[*]["containers"] : k => values(v) }
+  ecr_map   = zipmap(flatten(values(local.ecr_names)), flatten(values(local.ecr_data)))
+}
+
+# Prepare ECR repos for dependencies' images
+resource "aws_ecr_repository" "this" {
+  for_each = {
+    for c, v in local.ecr_map :
+    # omit the middle part (helm value path) off repo names for brevity reasons
+    "${split(".", c)[0]}.${split(".", c)[2]}" => v... if v.ecr_prepare_images
+  }
+  name                 = each.key
+  image_tag_mutability = each.value[0].ecr_immutable_tag ? "IMMUTABLE" : "MUTABLE"
+  force_delete         = true
+
+  image_scanning_configuration {
+    scan_on_push = each.value[0].ecr_scan_on_push
+  }
+
+  encryption_configuration {
+    encryption_type = each.value[0].ecr_encryption_type
+    kms_key         = each.value[0].ecr_encryption_type == "KMS" ? each.value[0].ecr_kms_key : null
+  }
+}
+
+# Push images from public source to ECR repos
+resource "skopeo_copy" "this" {
+  for_each = {
+    for c, v in local.ecr_map :
+    "${split(".", c)[0]}.${split(".", c)[2]}" => v... if v.ecr_prepare_images
+  }
+  source_image      = "docker://${each.value[0].src_reigstry}/${split(".", each.key)[1]}:${each.value[0].parsed_tag}"
+  destination_image = "docker://${aws_ecr_repository.this[each.key].repository_url}:${each.value[0].parsed_tag}"
+  keep_image        = true
+
+  depends_on = [
+    aws_ecr_repository.this
+  ]
+}

--- a/modules/aws/cert-manager.tf
+++ b/modules/aws/cert-manager.tf
@@ -136,9 +136,53 @@ resource "helm_release" "cert-manager" {
     local.values_cert-manager,
     local.cert-manager["extra_values"]
   ]
+
+  #TODO(bogdando): create a shared template and refer it in addons (copy-pasta until then)
+  dynamic "set" {
+    for_each = {
+      for c, v in local.images_data.cert-manager.containers :
+      c => v if v.rewrite_values.tag != null
+    }
+    content {
+      name  = set.value.rewrite_values.tag.name
+      value = try(local.cert-manager["containers_versions"][set.value.rewrite_values.tag.name], set.value.rewrite_values.tag.value)
+    }
+  }
+  dynamic "set" {
+    for_each = local.images_data.cert-manager.containers
+    content {
+      name = set.value.rewrite_values.image.name
+      value = set.value.ecr_prepare_images && set.value.source_provided ? "${
+        aws_ecr_repository.this[
+          format("%s.%s", split(".", set.key)[0], split(".", set.key)[2])
+        ].repository_url}${set.value.rewrite_values.image.tail
+        }" : set.value.ecr_prepare_images ? "${
+        aws_ecr_repository.this[
+          format("%s.%s", split(".", set.key)[0], split(".", set.key)[2])
+        ].name
+      }" : set.value.rewrite_values.image.value
+    }
+  }
+  dynamic "set" {
+    for_each = {
+      for c, v in local.images_data.cert-manager.containers :
+      c => v if v.rewrite_values.registry != null
+    }
+    content {
+      name = set.value.rewrite_values.registry.name
+      # when unset, it should be replaced with the one prepared on ECR
+      value = set.value.rewrite_values.registry.value != null ? set.value.rewrite_values.registry.value : split(
+        "/", aws_ecr_repository.this[
+          format("%s.%s", split(".", set.key)[0], split(".", set.key)[2])
+        ].repository_url
+      )[0]
+    }
+  }
+
   namespace = kubernetes_namespace.cert-manager.*.metadata.0.name[count.index]
 
   depends_on = [
+    skopeo_copy.this,
     kubectl_manifest.prometheus-operator_crds
   ]
 }

--- a/modules/aws/cluster-autoscaler.tf
+++ b/modules/aws/cluster-autoscaler.tf
@@ -10,7 +10,6 @@ locals {
       service_account_name      = "cluster-autoscaler"
       create_iam_resources_irsa = true
       enabled                   = false
-      version                   = "v1.21.1"
       iam_policy_override       = null
       default_network_policy    = true
       name_prefix               = "${var.cluster-name}-cluster-autoscaler"
@@ -29,9 +28,6 @@ rbac:
     name: ${local.cluster-autoscaler["service_account_name"]}
     annotations:
       eks.amazonaws.com/role-arn: "${local.cluster-autoscaler["enabled"] && local.cluster-autoscaler["create_iam_resources_irsa"] ? module.iam_assumable_role_cluster-autoscaler.iam_role_arn : ""}"
-image:
-  repository: k8s.gcr.io/autoscaling/cluster-autoscaler
-  tag: ${local.cluster-autoscaler["version"]}
 extraArgs:
   balance-similar-node-groups: true
   skip-nodes-with-local-storage: false
@@ -147,9 +143,53 @@ resource "helm_release" "cluster-autoscaler" {
     local.values_cluster-autoscaler,
     local.cluster-autoscaler["extra_values"]
   ]
+
+  #TODO(bogdando): create a shared template and refer it in addons (copy-pasta until then)
+  dynamic "set" {
+    for_each = {
+      for c, v in local.images_data.cluster-autoscaler.containers :
+      c => v if v.rewrite_values.tag != null
+    }
+    content {
+      name  = set.value.rewrite_values.tag.name
+      value = try(local.cluster-autoscaler["containers_versions"][set.value.rewrite_values.tag.name], set.value.rewrite_values.tag.value)
+    }
+  }
+  dynamic "set" {
+    for_each = local.images_data.cluster-autoscaler.containers
+    content {
+      name = set.value.rewrite_values.image.name
+      value = set.value.ecr_prepare_images && set.value.source_provided ? "${
+        aws_ecr_repository.this[
+          format("%s.%s", split(".", set.key)[0], split(".", set.key)[2])
+        ].repository_url}${set.value.rewrite_values.image.tail
+        }" : set.value.ecr_prepare_images ? "${
+        aws_ecr_repository.this[
+          format("%s.%s", split(".", set.key)[0], split(".", set.key)[2])
+        ].name
+      }" : set.value.rewrite_values.image.value
+    }
+  }
+  dynamic "set" {
+    for_each = {
+      for c, v in local.images_data.cluster-autoscaler.containers :
+      c => v if v.rewrite_values.registry != null
+    }
+    content {
+      name = set.value.rewrite_values.registry.name
+      # when unset, it should be replaced with the one prepared on ECR
+      value = set.value.rewrite_values.registry.value != null ? set.value.rewrite_values.registry.value : split(
+        "/", aws_ecr_repository.this[
+          format("%s.%s", split(".", set.key)[0], split(".", set.key)[2])
+        ].repository_url
+      )[0]
+    }
+  }
+
   namespace = kubernetes_namespace.cluster-autoscaler.*.metadata.0.name[count.index]
 
   depends_on = [
+    skopeo_copy.this,
     kubectl_manifest.prometheus-operator_crds
   ]
 }

--- a/modules/aws/external-dns.tf
+++ b/modules/aws/external-dns.tf
@@ -120,9 +120,53 @@ resource "helm_release" "external-dns" {
     local.values_external-dns[each.key]["values"],
     each.value["extra_values"]
   ]
+
+  #TODO(bogdando): create a shared template and refer it in addons (copy-pasta until then)
+  dynamic "set" {
+    for_each = {
+      for c, v in local.images_data.external-dns.containers :
+      c => v if v.rewrite_values.tag != null
+    }
+    content {
+      name  = set.value.rewrite_values.tag.name
+      value = try(local.external-dns["containers_versions"][set.value.rewrite_values.tag.name], set.value.rewrite_values.tag.value)
+    }
+  }
+  dynamic "set" {
+    for_each = local.images_data.external-dns.containers
+    content {
+      name = set.value.rewrite_values.image.name
+      value = set.value.ecr_prepare_images && set.value.source_provided ? "${
+        aws_ecr_repository.this[
+          format("%s.%s", split(".", set.key)[0], split(".", set.key)[2])
+        ].repository_url}${set.value.rewrite_values.image.tail
+        }" : set.value.ecr_prepare_images ? "${
+        aws_ecr_repository.this[
+          format("%s.%s", split(".", set.key)[0], split(".", set.key)[2])
+        ].name
+      }" : set.value.rewrite_values.image.value
+    }
+  }
+  dynamic "set" {
+    for_each = {
+      for c, v in local.images_data.external-dns.containers :
+      c => v if v.rewrite_values.registry != null
+    }
+    content {
+      name = set.value.rewrite_values.registry.name
+      # when unset, it should be replaced with the one prepared on ECR
+      value = set.value.rewrite_values.registry.value != null ? set.value.rewrite_values.registry.value : split(
+        "/", aws_ecr_repository.this[
+          format("%s.%s", split(".", set.key)[0], split(".", set.key)[2])
+        ].repository_url
+      )[0]
+    }
+  }
+
   namespace = kubernetes_namespace.external-dns[each.key].metadata.0.name
 
   depends_on = [
+    skopeo_copy.this,
     kubectl_manifest.prometheus-operator_crds
   ]
 }

--- a/modules/aws/iam/aws-efs-csi-driver.json
+++ b/modules/aws/iam/aws-efs-csi-driver.json
@@ -5,7 +5,9 @@
       "Effect": "Allow",
       "Action": [
         "elasticfilesystem:DescribeAccessPoints",
-        "elasticfilesystem:DescribeFileSystems"
+        "elasticfilesystem:DescribeFileSystems",
+        "elasticfilesystem:DescribeMountTargets",
+        "ec2:DescribeAvailabilityZones"
       ],
       "Resource": "*"
     },

--- a/modules/aws/ingress-nginx.tf
+++ b/modules/aws/ingress-nginx.tf
@@ -162,10 +162,53 @@ resource "helm_release" "ingress-nginx" {
     local.ingress-nginx["use_nlb_ip"] ? local.values_ingress-nginx_nlb_ip : local.ingress-nginx["use_nlb"] ? local.values_ingress-nginx_nlb : local.ingress-nginx["use_l7"] ? local.values_ingress-nginx_l7 : local.values_ingress-nginx_l4,
     local.ingress-nginx["extra_values"],
   ]
+
+  #TODO(bogdando): create a shared template and refer it in addons (copy-pasta until then)
+  dynamic "set" {
+    for_each = {
+      for c, v in local.images_data.ingress-nginx.containers :
+      c => v if v.rewrite_values.tag != null
+    }
+    content {
+      name  = set.value.rewrite_values.tag.name
+      value = try(local.ingress-nginx["containers_versions"][set.value.rewrite_values.tag.name], set.value.rewrite_values.tag.value)
+    }
+  }
+  dynamic "set" {
+    for_each = local.images_data.ingress-nginx.containers
+    content {
+      name = set.value.rewrite_values.image.name
+      value = set.value.ecr_prepare_images && set.value.source_provided ? "${
+        aws_ecr_repository.this[
+          format("%s.%s", split(".", set.key)[0], split(".", set.key)[2])
+        ].repository_url}${set.value.rewrite_values.image.tail
+        }" : set.value.ecr_prepare_images ? "${
+        aws_ecr_repository.this[
+          format("%s.%s", split(".", set.key)[0], split(".", set.key)[2])
+        ].name
+      }" : set.value.rewrite_values.image.value
+    }
+  }
+  dynamic "set" {
+    for_each = {
+      for c, v in local.images_data.ingress-nginx.containers :
+      c => v if v.rewrite_values.registry != null
+    }
+    content {
+      name = set.value.rewrite_values.registry.name
+      # when unset, it should be replaced with the one prepared on ECR
+      value = set.value.rewrite_values.registry.value != null ? set.value.rewrite_values.registry.value : split(
+        "/", aws_ecr_repository.this[
+          format("%s.%s", split(".", set.key)[0], split(".", set.key)[2])
+        ].repository_url
+      )[0]
+    }
+  }
+
   namespace = kubernetes_namespace.ingress-nginx.*.metadata.0.name[count.index]
 
   depends_on = [
-    kubectl_manifest.prometheus-operator_crds
+    kubectl_manifest.prometheus-operator_crds, skopeo_copy.this
   ]
 }
 

--- a/modules/aws/kube-prometheus.tf
+++ b/modules/aws/kube-prometheus.tf
@@ -475,11 +475,55 @@ resource "helm_release" "kube-prometheus-stack" {
     local.kube-prometheus-stack["default_global_limits"] ? local.values_kps_global_limits : null,
     local.kube-prometheus-stack["extra_values"]
   ])
+
+  #TODO(bogdando): create a shared template and refer it in addons (copy-pasta until then)
+  dynamic "set" {
+    for_each = {
+      for c, v in local.images_data.kube-prometheus-stack.containers :
+      c => v if v.rewrite_values.tag != null
+    }
+    content {
+      name  = set.value.rewrite_values.tag.name
+      value = try(local.kube-prometheus-stack["containers_versions"][set.value.rewrite_values.tag.name], set.value.rewrite_values.tag.value)
+    }
+  }
+  dynamic "set" {
+    for_each = local.images_data.kube-prometheus-stack.containers
+    content {
+      name = set.value.rewrite_values.image.name
+      value = set.value.ecr_prepare_images && set.value.source_provided ? "${
+        aws_ecr_repository.this[
+          format("%s.%s", split(".", set.key)[0], split(".", set.key)[2])
+        ].repository_url}${set.value.rewrite_values.image.tail
+        }" : set.value.ecr_prepare_images ? "${
+        aws_ecr_repository.this[
+          format("%s.%s", split(".", set.key)[0], split(".", set.key)[2])
+        ].name
+      }" : set.value.rewrite_values.image.value
+    }
+  }
+  dynamic "set" {
+    for_each = {
+      for c, v in local.images_data.kube-prometheus-stack.containers :
+      c => v if v.rewrite_values.registry != null
+    }
+    content {
+      name = set.value.rewrite_values.registry.name
+      # when unset, it should be replaced with the one prepared on ECR
+      value = set.value.rewrite_values.registry.value != null ? set.value.rewrite_values.registry.value : split(
+        "/", aws_ecr_repository.this[
+          format("%s.%s", split(".", set.key)[0], split(".", set.key)[2])
+        ].repository_url
+      )[0]
+    }
+  }
+
   namespace = kubernetes_namespace.kube-prometheus-stack.*.metadata.0.name[count.index]
 
   depends_on = [
     helm_release.ingress-nginx,
-    kubectl_manifest.prometheus-operator_crds
+    kubectl_manifest.prometheus-operator_crds,
+    skopeo_copy.this
   ]
 }
 

--- a/modules/aws/tigera-operator.tf
+++ b/modules/aws/tigera-operator.tf
@@ -58,9 +58,52 @@ resource "helm_release" "tigera-operator" {
     local.values_tigera-operator,
     local.tigera-operator["extra_values"]
   ]
+
+  #TODO(bogdando): create a shared template and refer it in addons (copy-pasta until then)
+  dynamic "set" {
+    for_each = {
+      for c, v in local.images_data.tigera-operator.containers :
+      c => v if v.rewrite_values.tag != null
+    }
+    content {
+      name  = set.value.rewrite_values.tag.name
+      value = try(local.tigera-operator["containers_versions"][set.value.rewrite_values.tag.name], set.value.rewrite_values.tag.value)
+    }
+  }
+  dynamic "set" {
+    for_each = local.images_data.tigera-operator.containers
+    content {
+      name = set.value.rewrite_values.image.name
+      value = set.value.ecr_prepare_images && set.value.source_provided ? "${
+        aws_ecr_repository.this[
+          format("%s.%s", split(".", set.key)[0], split(".", set.key)[2])
+        ].repository_url}${set.value.rewrite_values.image.tail
+        }" : set.value.ecr_prepare_images ? "${
+        aws_ecr_repository.this[
+          format("%s.%s", split(".", set.key)[0], split(".", set.key)[2])
+        ].name
+      }" : set.value.rewrite_values.image.value
+    }
+  }
+  dynamic "set" {
+    for_each = {
+      for c, v in local.images_data.tigera-operator.containers :
+      c => v if v.rewrite_values.registry != null
+    }
+    content {
+      name = set.value.rewrite_values.registry.name
+      # when unset, it should be replaced with the one prepared on ECR
+      value = set.value.rewrite_values.registry.value != null ? set.value.rewrite_values.registry.value : split(
+        "/", aws_ecr_repository.this[
+          format("%s.%s", split(".", set.key)[0], split(".", set.key)[2])
+        ].repository_url
+      )[0]
+    }
+  }
   namespace = local.tigera-operator["create_ns"] ? kubernetes_namespace.tigera-operator.*.metadata.0.name[count.index] : local.tigera-operator["namespace"]
 
   depends_on = [
+    skopeo_copy.this,
     kubectl_manifest.prometheus-operator_crds
   ]
 }

--- a/modules/aws/versions.tf
+++ b/modules/aws/versions.tf
@@ -16,6 +16,10 @@ terraform {
       source  = "integrations/github"
       version = "~> 5.0"
     }
+    skopeo = {
+      source  = "abergmeier/skopeo"
+      version = "0.0.4"
+    }
     tls = {
       source  = "hashicorp/tls"
       version = "~> 4.0"

--- a/modules/azure/node-problem-detector.tf
+++ b/modules/azure/node-problem-detector.tf
@@ -1,1 +1,101 @@
-../../node-problem-detector.tf
+locals {
+  npd = merge(
+    local.helm_defaults,
+    {
+      name                   = local.helm_dependencies[index(local.helm_dependencies.*.name, "node-problem-detector")].name
+      chart                  = local.helm_dependencies[index(local.helm_dependencies.*.name, "node-problem-detector")].name
+      repository             = local.helm_dependencies[index(local.helm_dependencies.*.name, "node-problem-detector")].repository
+      chart_version          = local.helm_dependencies[index(local.helm_dependencies.*.name, "node-problem-detector")].version
+      namespace              = "node-problem-detector"
+      enabled                = false
+      default_network_policy = true
+    },
+    var.npd
+  )
+
+  values_npd = <<VALUES
+priorityClassName: ${local.priority-class-ds["create"] ? kubernetes_priority_class.kubernetes_addons_ds[0].metadata[0].name : ""}
+VALUES
+
+}
+
+resource "kubernetes_namespace" "node-problem-detector" {
+  count = local.npd["enabled"] ? 1 : 0
+
+  metadata {
+    labels = {
+      name = local.npd["namespace"]
+    }
+
+    name = local.npd["namespace"]
+  }
+}
+
+resource "helm_release" "node-problem-detector" {
+  count                 = local.npd["enabled"] ? 1 : 0
+  repository            = local.npd["repository"]
+  name                  = local.npd["name"]
+  chart                 = local.npd["chart"]
+  version               = local.npd["chart_version"]
+  timeout               = local.npd["timeout"]
+  force_update          = local.npd["force_update"]
+  recreate_pods         = local.npd["recreate_pods"]
+  wait                  = local.npd["wait"]
+  atomic                = local.npd["atomic"]
+  cleanup_on_fail       = local.npd["cleanup_on_fail"]
+  dependency_update     = local.npd["dependency_update"]
+  disable_crd_hooks     = local.npd["disable_crd_hooks"]
+  disable_webhooks      = local.npd["disable_webhooks"]
+  render_subchart_notes = local.npd["render_subchart_notes"]
+  replace               = local.npd["replace"]
+  reset_values          = local.npd["reset_values"]
+  reuse_values          = local.npd["reuse_values"]
+  skip_crds             = local.npd["skip_crds"]
+  verify                = local.npd["verify"]
+  values = [
+    local.values_npd,
+    local.npd["extra_values"]
+  ]
+  namespace = kubernetes_namespace.node-problem-detector.*.metadata.0.name[count.index]
+}
+
+resource "kubernetes_network_policy" "npd_default_deny" {
+  count = local.npd["enabled"] && local.npd["default_network_policy"] ? 1 : 0
+
+  metadata {
+    name      = "${kubernetes_namespace.node-problem-detector.*.metadata.0.name[count.index]}-default-deny"
+    namespace = kubernetes_namespace.node-problem-detector.*.metadata.0.name[count.index]
+  }
+
+  spec {
+    pod_selector {
+    }
+    policy_types = ["Ingress"]
+  }
+}
+
+resource "kubernetes_network_policy" "npd_allow_namespace" {
+  count = local.npd["enabled"] && local.npd["default_network_policy"] ? 1 : 0
+
+  metadata {
+    name      = "${kubernetes_namespace.node-problem-detector.*.metadata.0.name[count.index]}-allow-namespace"
+    namespace = kubernetes_namespace.node-problem-detector.*.metadata.0.name[count.index]
+  }
+
+  spec {
+    pod_selector {
+    }
+
+    ingress {
+      from {
+        namespace_selector {
+          match_labels = {
+            name = kubernetes_namespace.node-problem-detector.*.metadata.0.name[count.index]
+          }
+        }
+      }
+    }
+
+    policy_types = ["Ingress"]
+  }
+}

--- a/node-problem-detector.tf
+++ b/node-problem-detector.tf
@@ -56,7 +56,54 @@ resource "helm_release" "node-problem-detector" {
     local.values_npd,
     local.npd["extra_values"]
   ]
+
+  #TODO(bogdando): create a shared template and refer it in addons (copy-pasta until then)
+  dynamic "set" {
+    for_each = {
+      for c, v in local.images_data.node-problem-detector.containers :
+      c => v if v.rewrite_values.tag != null
+    }
+    content {
+      name  = set.value.rewrite_values.tag.name
+      value = try(local.npd["containers_versions"][set.value.rewrite_values.tag.name], set.value.rewrite_values.tag.value)
+    }
+  }
+  dynamic "set" {
+    for_each = local.images_data.node-problem-detector.containers
+    content {
+      name = set.value.rewrite_values.image.name
+      value = set.value.ecr_prepare_images && set.value.source_provided ? "${
+        aws_ecr_repository.this[
+          format("%s.%s", split(".", set.key)[0], split(".", set.key)[2])
+        ].repository_url}${set.value.rewrite_values.image.tail
+        }" : set.value.ecr_prepare_images ? "${
+        aws_ecr_repository.this[
+          format("%s.%s", split(".", set.key)[0], split(".", set.key)[2])
+        ].name
+      }" : set.value.rewrite_values.image.value
+    }
+  }
+  dynamic "set" {
+    for_each = {
+      for c, v in local.images_data.node-problem-detector.containers :
+      c => v if v.rewrite_values.registry != null
+    }
+    content {
+      name = set.value.rewrite_values.registry.name
+      # when unset, it should be replaced with the one prepared on ECR
+      value = set.value.rewrite_values.registry.value != null ? set.value.rewrite_values.registry.value : split(
+        "/", aws_ecr_repository.this[
+          format("%s.%s", split(".", set.key)[0], split(".", set.key)[2])
+        ].repository_url
+      )[0]
+    }
+  }
+
   namespace = kubernetes_namespace.node-problem-detector.*.metadata.0.name[count.index]
+
+  depends_on = [
+    skopeo_copy.this
+  ]
 }
 
 resource "kubernetes_network_policy" "npd_default_deny" {

--- a/versions.tf
+++ b/versions.tf
@@ -15,6 +15,10 @@ terraform {
       source  = "integrations/github"
       version = "~> 5.0"
     }
+    skopeo = {
+      source  = "abergmeier/skopeo"
+      version = "0.0.4"
+    }
     tls = {
       source  = "hashicorp/tls"
       version = "~> 4.0"


### PR DESCRIPTION
# Pull request title

Prepare AWS ECR containers images

## Description

For private AWS EKS clusters, public container images URI
can not always be available. For example, when deploying it
without NAT Gateways, relying on ECR service endpoints for
internal AWS traffic only.

In such a scenario, reconfiguring all Helm/Kubectl-managed
values for containers images, like names, tags, and registries,
becomes non-trivial and error-prone task.

Add feature to prepare ECR images based on provided containers
data for addons in helm-dependencies.yaml. Document example
containers data sections in helm-dependencies.yaml.

TODO: find a better place to provide containers data for
kubectl-managed addons alongside the helm-managed ones, or rename
the file to dependencies.yaml maybe.

TODO: existing versions-checker and updater automation to keep
default tags for containers in the dependencies file up to date.
This can be achieved via skopeo list-tags and skopeo inspect CLI.

The workflow to prepare images is the following:
* User tweaks the addons' 'containers_versions' inputs, like:

  ```
  addons_versions:
    kube-prometheus-stack:
      grafana.image: 9.1.0
    cluster_autoscaler:
      image: v1.21.2
  ```
  Then using it like that:
  ```
  cluster-autoscaler = {
    containers_versions = local.addons_versions.cluster-autoscaler
    extra_values = <<-EXTRA_VALUES
    # anything but containers images-related data
    EXTRA_VALUES
  }
  kube-prometheus-stack = {
    containers_versions local.addon_versions.kube-prometheus-stack
  ...
  ```
* Before deploying with terraform/terragrunt, user logs in into
  ECR.
* The AWS eks addons module ensures ECR repositories with the
  given options (documented in examples in helm-dependencies.yaml)
* The AWS eks addons module ensures containers images copied with
  skopeo into ECR from the sources provided in the containers data
* The AWS eks addons module reconfigures helm_release resources
  (TODO: also for kube_manifest ones):
  * When, source data provided, the full name data contains a registry
    URI, which becomes rewritten with the prepared ECR repo URL
  * When no source data provided, the short name data gets adjusted
    to properly point the prepared ECR image name
  * When registry data provided, that public URL becomes rewritten with
    the prepared ECR repo URL
  * Tags information, if provided gets configured for Helm as is.

  TODO: not all addons currently support this automation. Also, it
  should be moved to some shared templating module to avoid copy-pasting
  dynamic "set" {} sections for all helm_release resources of all addons.

implements: https://github.com/particuleio/terraform-kubernetes-addons/issues/1326

Signed-off-by: Bogdan Dobrelya <bogdando@yahoo.com>
Signed-off-by: Bogdan Dobrelia <bogdan.dobrelia@spearline.com>

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/particuleio/terraform-kubernetes-addons/#doc-generation
