### PR TITLE
fix(tf): Addons using tls-acme to depend on cert-manager

### DIFF
--- a/modules/aws/cert-manager.tf
+++ b/modules/aws/cert-manager.tf
@@ -139,7 +139,7 @@ resource "helm_release" "cert-manager" {
   namespace = kubernetes_namespace.cert-manager.*.metadata.0.name[count.index]
 
   depends_on = [
-    helm_release.kube-prometheus-stack
+    kubectl_manifest.prometheus-operator_crds
   ]
 }
 

--- a/modules/aws/kube-prometheus.tf
+++ b/modules/aws/kube-prometheus.tf
@@ -478,6 +478,7 @@ resource "helm_release" "kube-prometheus-stack" {
   namespace = kubernetes_namespace.kube-prometheus-stack.*.metadata.0.name[count.index]
 
   depends_on = [
+    helm_release.cert-manager,
     helm_release.ingress-nginx,
     kubectl_manifest.prometheus-operator_crds
   ]


### PR DESCRIPTION
# Pull request title

Addons using tls-acme to depend on cert-manager

## Description

Tls-acme annotation used with prometheus/grafana and loki implies dependency on cert-manager addon. Make it explicit for the former. No changes needed for the latter as loki already depends on the prometheus addon.

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/particuleio/terraform-kubernetes-addons/#doc-generation
