### PR TITLE
fix(ingress-nginx): metrics port name change

### DIFF
--- a/ingress-nginx.tf
+++ b/ingress-nginx.tf
@@ -177,7 +177,7 @@ resource "kubernetes_network_policy" "ingress-nginx_allow_monitoring" {
 
     ingress {
       ports {
-        port     = "http-metrics"
+        port     = "metrics"
         protocol = "TCP"
       }
 

--- a/modules/aws/ingress-nginx.tf
+++ b/modules/aws/ingress-nginx.tf
@@ -265,7 +265,7 @@ resource "kubernetes_network_policy" "ingress-nginx_allow_monitoring" {
 
     ingress {
       ports {
-        port     = "http-metrics"
+        port     = "metrics"
         protocol = "TCP"
       }
 

--- a/modules/scaleway/ingress-nginx.tf
+++ b/modules/scaleway/ingress-nginx.tf
@@ -185,7 +185,7 @@ resource "kubernetes_network_policy" "ingress-nginx_allow_monitoring" {
 
     ingress {
       ports {
-        port     = "http-metrics"
+        port     = "metrics"
         protocol = "TCP"
       }
 


### PR DESCRIPTION
# fix(ingress-nginx): metrics port name change

## Description

Following ingress-nginx chart upgrade, port name have changed.
