### PR TITLE
feat: Adding optional kms key id to encrypt cw log group for fluent bit

### DIFF
--- a/modules/aws/aws-for-fluent-bit.tf
+++ b/modules/aws/aws-for-fluent-bit.tf
@@ -14,6 +14,7 @@ locals {
       iam_policy_override              = null
       default_network_policy           = true
       containers_log_retention_in_days = 180
+      kms_key_id                       = ""
       name_prefix                      = "${var.cluster-name}-aws-for-fluent-bit"
     },
     var.aws-for-fluent-bit
@@ -80,6 +81,7 @@ resource "aws_cloudwatch_log_group" "aws-for-fluent-bit" {
   count             = local.aws-for-fluent-bit["enabled"] ? 1 : 0
   name              = "/aws/eks/${var.cluster-name}/containers"
   retention_in_days = local.aws-for-fluent-bit["containers_log_retention_in_days"]
+  kms_key_id        = local.aws-for-fluent-bit["containers_log_retention_in_days"]
 }
 
 resource "kubernetes_namespace" "aws-for-fluent-bit" {

--- a/modules/aws/aws-for-fluent-bit.tf
+++ b/modules/aws/aws-for-fluent-bit.tf
@@ -14,7 +14,7 @@ locals {
       iam_policy_override              = null
       default_network_policy           = true
       containers_log_retention_in_days = 180
-      kms_key_id                       = ""
+      kms_key_id                       = null
       name_prefix                      = "${var.cluster-name}-aws-for-fluent-bit"
     },
     var.aws-for-fluent-bit

--- a/modules/aws/aws-for-fluent-bit.tf
+++ b/modules/aws/aws-for-fluent-bit.tf
@@ -81,7 +81,7 @@ resource "aws_cloudwatch_log_group" "aws-for-fluent-bit" {
   count             = local.aws-for-fluent-bit["enabled"] ? 1 : 0
   name              = "/aws/eks/${var.cluster-name}/containers"
   retention_in_days = local.aws-for-fluent-bit["containers_log_retention_in_days"]
-  kms_key_id        = local.aws-for-fluent-bit["containers_log_retention_in_days"]
+  kms_key_id        = local.aws-for-fluent-bit["kms_key_id"]
 }
 
 resource "kubernetes_namespace" "aws-for-fluent-bit" {


### PR DESCRIPTION
# Adding optional kms key id to encrypt cw log group for fluent bit

## Description

Adding optional kms key id to encrypt cw log group for fluent bit

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/particuleio/terraform-kubernetes-addons/#doc-generation
