### PR TITLE
fix: decouple canary from self-monitoring

### DIFF
--- a/modules/aws/loki-stack.tf
+++ b/modules/aws/loki-stack.tf
@@ -29,12 +29,12 @@ locals {
     test:
       enabled: false
     monitoring:
+      lokiCanary:
+        enabled: false    
       selfMonitoring:
         enabled: false
         grafanaAgent:
           installOperator: false
-        lokiCanary:
-          enabled: false
     serviceMonitor:
       enabled: ${local.kube-prometheus-stack["enabled"] || local.victoria-metrics-k8s-stack["enabled"]}
     priorityClassName: ${local.priority-class["create"] ? kubernetes_priority_class.kubernetes_addons[0].metadata[0].name : ""}

--- a/modules/scaleway/loki-stack.tf
+++ b/modules/scaleway/loki-stack.tf
@@ -25,12 +25,12 @@ locals {
     global
       dnsService: coredns
     monitoring:
+      lokiCanary:
+        enabled: false    
       selfMonitoring:
         enabled: false
         grafanaAgent:
           installOperator: false
-        lokiCanary:
-          enabled: false
     serviceMonitor:
       enabled: ${local.kube-prometheus-stack["enabled"] || local.victoria-metrics-k8s-stack["enabled"]}
     priorityClassName: ${local.priority-class["create"] ? kubernetes_priority_class.kubernetes_addons[0].metadata[0].name : ""}


### PR DESCRIPTION
# Move canary out from self-monitoring

## Description

Currently you cannot disable canary daemon set as it needs to be moved out from self-monitoring.
More details on this here: https://github.com/grafana/loki/pull/7757

### Checklist

- [x] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/particuleio/terraform-kubernetes-addons/#doc-generation
