### PR TITLE
fix: revert "fix(charts): update helm release ingress-nginx to v4.4.3 (#1761)"

### DIFF
--- a/helm-dependencies.yaml
+++ b/helm-dependencies.yaml
@@ -42,7 +42,7 @@ dependencies:
     version: 1.13.3
     repository: https://charts.fluxcd.io
   - name: ingress-nginx
-    version: 4.4.3
+    version: 4.4.2
     repository: https://kubernetes.github.io/ingress-nginx
   - name: istio-operator
     version: 1.7.0


### PR DESCRIPTION
This reverts commit 92ecd7ff8c6558923bbcb6b24776264f0f95b406.

# Pull request title
Fixes #1773 

## Description

As decribed in the issue #1773 , ingress-nginx helm chart 4.4.3 doesn't exist in the repo. This revert to 4.4.2

### Checklist

- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/particuleio/terraform-kubernetes-addons/#doc-generation
