### PR TITLE
feat: Allow throughput_mode elastic configuration in aws efs csi

### DIFF
--- a/modules/aws/README.md
+++ b/modules/aws/README.md
@@ -21,7 +21,7 @@ This module can uses [IRSA](https://aws.amazon.com/blogs/opensource/introducing-
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.72 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.42 |
 | <a name="requirement_flux"></a> [flux](#requirement\_flux) | ~> 0.23 |
 | <a name="requirement_github"></a> [github](#requirement\_github) | ~> 5.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0 |
@@ -34,7 +34,7 @@ This module can uses [IRSA](https://aws.amazon.com/blogs/opensource/introducing-
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.72 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.42 |
 | <a name="provider_flux"></a> [flux](#provider\_flux) | ~> 0.23 |
 | <a name="provider_github"></a> [github](#provider\_github) | ~> 5.0 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | ~> 2.0 |

--- a/modules/aws/aws-efs-csi-driver.tf
+++ b/modules/aws/aws-efs-csi-driver.tf
@@ -92,7 +92,7 @@ resource "aws_efs_file_system" "aws-efs-csi-driver" {
   encrypted                       = lookup(local.aws-efs-csi-driver, "encrypted", "true")
   performance_mode                = lookup(local.aws-efs-csi-driver, "performance_mode", "generalPurpose")
   provisioned_throughput_in_mibps = lookup(local.aws-efs-csi-driver, "provisioned_throughput_in_mibps", 0)
-  throughput_mode                 = lookup(local.aws-efs-csi-driver, "provisioned_throughput_in_mibps", 0) == 0 ? "bursting" : "provisioned"
+  throughput_mode                 = lookup(local.aws-efs-csi-driver, "throughput_mode", "bursting")
   dynamic "lifecycle_policy" {
     for_each = lookup(local.aws-efs-csi-driver, "lifecycle_policy", [])
     content {

--- a/modules/aws/versions.tf
+++ b/modules/aws/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_version = ">= 1.0"
   required_providers {
-    aws        = ">= 3.72"
+    aws        = ">= 4.42"
     helm       = "~> 2.0"
     kubernetes = "~> 2.0, != 2.12"
     kubectl = {


### PR DESCRIPTION
# Allow throughput_mode to be configured independently for aws efs csi


## Description

Currently provisioned_throughput_in_mibps is used as a variable to both configure provisioned_throughput_in_mibps and throughput_mode. In November of 2022 AWS [announced](https://aws.amazon.com/blogs/aws/new-announcing-amazon-efs-elastic-throughput/) the elastic throughput mode. The AWS provider added support for the elastic option in https://github.com/hashicorp/terraform-provider-aws/pull/28054 which was released in v4.42.0

This PR opens up the throughput_mode for direct configuration.

This looks like a breaking change for this module.

### Checklist

- [x] CI tests are passing
- [X] README.md has been updated after any changes to variables and outputs. See https://github.com/particuleio/terraform-kubernetes-addons/#doc-generation
