### PR TITLE
fix: add small fixes for linkerd when enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,8 @@ No modules.
 | [kubernetes_network_policy.kube-prometheus-stack_default_deny](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.kyverno_allow_namespace](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.kyverno_default_deny](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
+| [kubernetes_network_policy.linkerd-viz_allow_control_plane](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
+| [kubernetes_network_policy.linkerd-viz_allow_monitoring](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.linkerd-viz_allow_namespace](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.linkerd-viz_default_deny](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.linkerd2-cni_allow_namespace](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |

--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ No modules.
 | [kubernetes_network_policy.flux_default_deny](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.ingress-nginx_allow_control_plane](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.ingress-nginx_allow_ingress](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
+| [kubernetes_network_policy.ingress-nginx_allow_linkerd_viz](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.ingress-nginx_allow_monitoring](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.ingress-nginx_allow_namespace](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.ingress-nginx_default_deny](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |

--- a/ingress-nginx.tf
+++ b/ingress-nginx.tf
@@ -230,3 +230,29 @@ resource "kubernetes_network_policy" "ingress-nginx_allow_control_plane" {
     policy_types = ["Ingress"]
   }
 }
+
+resource "kubernetes_network_policy" "ingress-nginx_allow_linkerd_viz" {
+  count = local.ingress-nginx["enabled"] && local.linkerd-viz["enabled"] && local.ingress-nginx["default_network_policy"] ? 1 : 0
+
+  metadata {
+    name      = "${kubernetes_namespace.ingress-nginx.*.metadata.0.name[count.index]}-allow-linkerd-viz"
+    namespace = kubernetes_namespace.ingress-nginx.*.metadata.0.name[count.index]
+  }
+
+  spec {
+    pod_selector {
+    }
+
+    ingress {
+      from {
+        namespace_selector {
+          match_labels = {
+            name = local.linkerd-viz["namespace"]
+          }
+        }
+      }
+    }
+
+    policy_types = ["Ingress"]
+  }
+}

--- a/linkerd-viz.tf
+++ b/linkerd-viz.tf
@@ -149,6 +149,8 @@ resource "helm_release" "linkerd-viz" {
     local.linkerd-viz.ha ? local.values_linkerd-viz_ha : null
   ])
   namespace = local.linkerd-viz["create_ns"] ? kubernetes_namespace.linkerd-viz.*.metadata.0.name[count.index] : local.linkerd-viz["namespace"]
+
+  depends_on = [helm_release.linkerd-control-plane]
 }
 
 resource "kubernetes_network_policy" "linkerd-viz_default_deny" {

--- a/linkerd-viz.tf
+++ b/linkerd-viz.tf
@@ -17,9 +17,7 @@ locals {
   )
 
   values_linkerd-viz = <<VALUES
-    namespace: ${local.linkerd-viz.namespace}
-    installNamespace: false
-
+    linkerdNamespace: ${local.linkerd["namespace"]}
     VALUES
 
   values_linkerd-viz_ha = <<VALUES

--- a/linkerd-viz.tf
+++ b/linkerd-viz.tf
@@ -10,6 +10,7 @@ locals {
       create_ns              = true
       enabled                = local.linkerd.enabled
       default_network_policy = true
+      allowed_cidrs          = ["0.0.0.0/0"]
       ha                     = true
     },
     var.linkerd-viz
@@ -185,6 +186,64 @@ resource "kubernetes_network_policy" "linkerd-viz_allow_namespace" {
         namespace_selector {
           match_labels = {
             name = kubernetes_namespace.linkerd-viz.*.metadata.0.name[count.index]
+          }
+        }
+      }
+    }
+
+    policy_types = ["Ingress"]
+  }
+}
+
+resource "kubernetes_network_policy" "linkerd-viz_allow_control_plane" {
+  count = local.linkerd-viz["enabled"] && local.linkerd-viz["default_network_policy"] ? 1 : 0
+
+  metadata {
+    name      = "${kubernetes_namespace.linkerd-viz.*.metadata.0.name[count.index]}-allow-control-plane"
+    namespace = kubernetes_namespace.linkerd-viz.*.metadata.0.name[count.index]
+  }
+
+  spec {
+    pod_selector {
+    }
+
+    ingress {
+      ports {
+        port     = "8089"
+        protocol = "TCP"
+      }
+
+      dynamic "from" {
+        for_each = local.linkerd-viz["allowed_cidrs"]
+        content {
+          ip_block {
+            cidr = from.value
+          }
+        }
+      }
+    }
+
+    policy_types = ["Ingress"]
+  }
+}
+
+resource "kubernetes_network_policy" "linkerd-viz_allow_monitoring" {
+  count = local.linkerd-viz["enabled"] && local.linkerd-viz["default_network_policy"] ? 1 : 0
+
+  metadata {
+    name      = "${kubernetes_namespace.linkerd-viz.*.metadata.0.name[count.index]}-allow-monitoring"
+    namespace = kubernetes_namespace.linkerd-viz.*.metadata.0.name[count.index]
+  }
+
+  spec {
+    pod_selector {
+    }
+
+    ingress {
+      from {
+        namespace_selector {
+          match_labels = {
+            "${local.labels_prefix}/component" = "monitoring"
           }
         }
       }

--- a/linkerd2-cni.tf
+++ b/linkerd2-cni.tf
@@ -16,22 +16,6 @@ locals {
   )
 
   values_linkerd2-cni = <<VALUES
-    namespace: ${local.linkerd2-cni.namespace}
-    extraInitContainers:
-      - name: wait-for-other-cni
-        image: busybox:1.33
-        command:
-          - /bin/sh
-          - -xc
-          - |
-            for i in $(seq 1 180); do
-              test -f /host/etc/cni/net.d/${local.linkerd2-cni.cni_conflist_filename} && exit 0
-              sleep 1
-            done
-            exit 1
-        volumeMounts:
-          - mountPath: /host/etc/cni/net.d
-            name: cni-net-dir
     VALUES
 }
 

--- a/modules/aws/README.md
+++ b/modules/aws/README.md
@@ -268,6 +268,8 @@ This module can uses [IRSA](https://aws.amazon.com/blogs/opensource/introducing-
 | [kubernetes_network_policy.kube-prometheus-stack_default_deny](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.kyverno_allow_namespace](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.kyverno_default_deny](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
+| [kubernetes_network_policy.linkerd-viz_allow_control_plane](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
+| [kubernetes_network_policy.linkerd-viz_allow_monitoring](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.linkerd-viz_allow_namespace](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.linkerd-viz_default_deny](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.linkerd2-cni_allow_namespace](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |

--- a/modules/azure/README.md
+++ b/modules/azure/README.md
@@ -148,6 +148,8 @@ No modules.
 | [kubernetes_network_policy.kube-prometheus-stack_default_deny](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.kyverno_allow_namespace](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.kyverno_default_deny](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
+| [kubernetes_network_policy.linkerd-viz_allow_control_plane](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
+| [kubernetes_network_policy.linkerd-viz_allow_monitoring](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.linkerd-viz_allow_namespace](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.linkerd-viz_default_deny](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.linkerd2-cni_allow_namespace](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |

--- a/modules/scaleway/README.md
+++ b/modules/scaleway/README.md
@@ -171,6 +171,8 @@ No modules.
 | [kubernetes_network_policy.kube-prometheus-stack_default_deny](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.kyverno_allow_namespace](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.kyverno_default_deny](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
+| [kubernetes_network_policy.linkerd-viz_allow_control_plane](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
+| [kubernetes_network_policy.linkerd-viz_allow_monitoring](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.linkerd-viz_allow_namespace](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.linkerd-viz_default_deny](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.linkerd2-cni_allow_namespace](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |


### PR DESCRIPTION
# Fixes to Linkerd module

## Description

* add a `depends_on` linkerd-control-plane for linkerd-viz
* create new networkPolicies to linkerd-viz when `default_network_policy = true`
* create new networkPolicy to ingress-nginx when `default_network_policy = true`

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/particuleio/terraform-kubernetes-addons/#doc-generation
