### PR TITLE
feat: add Linkerd ServerAuthorization manifest

### DIFF
--- a/linkerd-viz.tf
+++ b/linkerd-viz.tf
@@ -62,7 +62,7 @@ locals {
     VALUES
 
   linkerd-viz_manifests = {
-    prometheus-servicemonitor = <<-VALUES
+    prometheus-servicemonitor         = <<-VALUES
       apiVersion: monitoring.coreos.com/v1
       kind: ServiceMonitor
       metadata:
@@ -94,6 +94,18 @@ locals {
         selector:
           matchLabels:
             component: prometheus
+      VALUES
+    allow-prometheus-admin-federation = <<-VALUES
+      apiVersion: policy.linkerd.io/v1beta1
+      kind: ServerAuthorization
+      metadata:
+        namespace: ${local.linkerd-viz.namespace}
+        name: prometheus-admin-federation
+      spec:
+        server:
+          name: prometheus-admin
+        client:
+          unauthenticated: true
       VALUES
   }
 }

--- a/modules/aws/README.md
+++ b/modules/aws/README.md
@@ -242,6 +242,7 @@ This module can uses [IRSA](https://aws.amazon.com/blogs/opensource/introducing-
 | [kubernetes_network_policy.flux_default_deny](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.ingress-nginx_allow_control_plane](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.ingress-nginx_allow_ingress](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
+| [kubernetes_network_policy.ingress-nginx_allow_linkerd_viz](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.ingress-nginx_allow_monitoring](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.ingress-nginx_allow_namespace](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.ingress-nginx_default_deny](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |

--- a/modules/scaleway/README.md
+++ b/modules/scaleway/README.md
@@ -145,6 +145,7 @@ No modules.
 | [kubernetes_network_policy.flux_default_deny](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.ingress-nginx_allow_control_plane](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.ingress-nginx_allow_ingress](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
+| [kubernetes_network_policy.ingress-nginx_allow_linkerd_viz](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.ingress-nginx_allow_monitoring](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.ingress-nginx_allow_namespace](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.ingress-nginx_default_deny](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |

--- a/modules/scaleway/ingress-nginx.tf
+++ b/modules/scaleway/ingress-nginx.tf
@@ -10,6 +10,8 @@ locals {
       namespace              = "ingress-nginx"
       enabled                = false
       default_network_policy = true
+      linkerd-viz-enabled    = false
+      linkerd-viz-namespace  = "linkerd-viz"
       ingress_cidrs          = ["0.0.0.0/0"]
       allowed_cidrs          = ["0.0.0.0/0"]
     },
@@ -230,6 +232,32 @@ resource "kubernetes_network_policy" "ingress-nginx_allow_control_plane" {
         content {
           ip_block {
             cidr = from.value
+          }
+        }
+      }
+    }
+
+    policy_types = ["Ingress"]
+  }
+}
+
+resource "kubernetes_network_policy" "ingress-nginx_allow_linkerd_viz" {
+  count = local.ingress-nginx["enabled"] && (local.linkerd-viz["enabled"] || local.ingress-nginx["linkerd-viz-enabled"]) && local.ingress-nginx["default_network_policy"] ? 1 : 0
+
+  metadata {
+    name      = "${kubernetes_namespace.ingress-nginx.*.metadata.0.name[count.index]}-allow-linkerd-viz"
+    namespace = kubernetes_namespace.ingress-nginx.*.metadata.0.name[count.index]
+  }
+
+  spec {
+    pod_selector {
+    }
+
+    ingress {
+      from {
+        namespace_selector {
+          match_labels = {
+            name = local.linkerd-viz["enabled"] ? local.linkerd-viz["namespace"] : local.ingress-nginx["linkerd-viz-namespace"]
           }
         }
       }


### PR DESCRIPTION
# Create a Linkerd ServerAuthorization manifest to allow prometheus federation

## Description

Linkerd-viz comes with a Prometheus instance with short lived data (6h). The easiest solution when kube-prometheus-stack is already deployed, is to use Prometheus federation for kube-prometheus-stack to scrape Linkerd metrics.
By default, Linkerd-viz comes with network restrictions preventing unmeshed pods to reach its namespace. 

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/particuleio/terraform-kubernetes-addons/#doc-generation
