### PR TITLE
fix: new port for metrics-server-allow-control-plane NetworkPolicy

### DIFF
--- a/metrics-server.tf
+++ b/metrics-server.tf
@@ -122,7 +122,7 @@ resource "kubernetes_network_policy" "metrics-server_allow_control_plane" {
 
     ingress {
       ports {
-        port     = "4443"
+        port     = "10250"
         protocol = "TCP"
       }
 


### PR DESCRIPTION
# New port for metrics-server-allow-control-plane NetworkPolicy

## Description

[v12.8.0](https://github.com/particuleio/terraform-kubernetes-addons/releases/tag/v12.8.0) has updated metrics-server chart to v3.10.0 (https://github.com/particuleio/terraform-kubernetes-addons/pull/1932), which [changed the container port from 4443 to 10250](https://github.com/kubernetes-sigs/metrics-server/compare/metrics-server-helm-chart-3.9.0...metrics-server-helm-chart-3.10.0#diff-388bebf658e7a2cd5fee27a4c120a71575fc2cd0f8ca0ea48d4add89e4e1ddc4R67). 
The networkpolicy `metrics-server-allow-control-plane` was not allowing traffic anymore, resulting in the apiService `v1beta1.metrics.k8s.io` to be down.

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/particuleio/terraform-kubernetes-addons/#doc-generation
