### PR TITLE
fix: Fix "The bucket does not allow ACLs" error for thanos S3 bucket

### DIFF
--- a/modules/aws/kube-prometheus.tf
+++ b/modules/aws/kube-prometheus.tf
@@ -401,10 +401,8 @@ module "kube-prometheus-stack_thanos_bucket" {
   source  = "terraform-aws-modules/s3-bucket/aws"
   version = "~> 3.0"
 
-  block_public_acls       = true
-  block_public_policy     = true
-  restrict_public_buckets = true
-  ignore_public_acls      = true
+  control_object_ownership = true
+  object_ownership         = "BucketOwnerEnforced"
 
   force_destroy = local.kube-prometheus-stack["thanos_bucket_force_destroy"]
 

--- a/modules/aws/loki-stack.tf
+++ b/modules/aws/loki-stack.tf
@@ -188,10 +188,8 @@ module "loki_bucket" {
   source  = "terraform-aws-modules/s3-bucket/aws"
   version = "~> 3.0"
 
-  block_public_acls       = true
-  block_public_policy     = true
-  restrict_public_buckets = true
-  ignore_public_acls      = true
+  control_object_ownership = true
+  object_ownership         = "BucketOwnerEnforced"
 
   force_destroy = local.loki-stack["bucket_force_destroy"]
 

--- a/modules/aws/s3-logging.tf
+++ b/modules/aws/s3-logging.tf
@@ -15,10 +15,8 @@ module "s3_logging_bucket" {
   source  = "terraform-aws-modules/s3-bucket/aws"
   version = "~> 3.0"
 
-  block_public_acls       = true
-  block_public_policy     = true
-  restrict_public_buckets = true
-  ignore_public_acls      = true
+  control_object_ownership = true
+  object_ownership         = "BucketOwnerEnforced"
 
   bucket = "${var.cluster-name}-eks-addons-s3-logging"
   acl    = "private"

--- a/modules/aws/thanos.tf
+++ b/modules/aws/thanos.tf
@@ -269,10 +269,8 @@ module "thanos_bucket" {
   source  = "terraform-aws-modules/s3-bucket/aws"
   version = "~> 3.0"
 
-  block_public_acls       = true
-  block_public_policy     = true
-  restrict_public_buckets = true
-  ignore_public_acls      = true
+  control_object_ownership = true
+  object_ownership         = "BucketOwnerEnforced"
 
   force_destroy = local.thanos["bucket_force_destroy"]
 

--- a/modules/aws/velero.tf
+++ b/modules/aws/velero.tf
@@ -163,10 +163,8 @@ module "velero_thanos_bucket" {
   source  = "terraform-aws-modules/s3-bucket/aws"
   version = "~> 3.0"
 
-  block_public_acls       = true
-  block_public_policy     = true
-  restrict_public_buckets = true
-  ignore_public_acls      = true
+  control_object_ownership = true
+  object_ownership         = "BucketOwnerEnforced"
 
   force_destroy = local.velero.bucket_force_destroy
 


### PR DESCRIPTION
# Fix "The bucket does not allow ACLs" error for Thanos's S3 bucket

## Description

Amazon issued the [article](https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/) recently saying that all newly created buckets will by default have S3 Block Public Access enabled and ACLs disabled.

It's been already taken into account in the underlying module in [this](https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/pull/226) PR but they changed the defaults, and this brakes the kube-prometheus-stack module

This PR fixes this issue

### Checklist

- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/particuleio/terraform-kubernetes-addons/#doc-generation
