### PR TITLE
feat: Add optional role parameter for cert-manager add-on

### DIFF
--- a/modules/aws/cert-manager.tf
+++ b/modules/aws/cert-manager.tf
@@ -3,23 +3,24 @@ locals {
   cert-manager = merge(
     local.helm_defaults,
     {
-      name                      = local.helm_dependencies[index(local.helm_dependencies.*.name, "cert-manager")].name
-      chart                     = local.helm_dependencies[index(local.helm_dependencies.*.name, "cert-manager")].name
-      repository                = local.helm_dependencies[index(local.helm_dependencies.*.name, "cert-manager")].repository
-      chart_version             = local.helm_dependencies[index(local.helm_dependencies.*.name, "cert-manager")].version
-      namespace                 = "cert-manager"
-      service_account_name      = "cert-manager"
-      create_iam_resources_irsa = true
-      enabled                   = false
-      iam_policy_override       = null
-      default_network_policy    = true
-      acme_email                = "contact@acme.com"
-      acme_http01_enabled       = true
-      acme_http01_ingress_class = "nginx"
-      acme_dns01_enabled        = true
-      allowed_cidrs             = ["0.0.0.0/0"]
-      csi_driver                = false
-      name_prefix               = "${var.cluster-name}-cert-manager"
+      name                           = local.helm_dependencies[index(local.helm_dependencies.*.name, "cert-manager")].name
+      chart                          = local.helm_dependencies[index(local.helm_dependencies.*.name, "cert-manager")].name
+      repository                     = local.helm_dependencies[index(local.helm_dependencies.*.name, "cert-manager")].repository
+      chart_version                  = local.helm_dependencies[index(local.helm_dependencies.*.name, "cert-manager")].version
+      namespace                      = "cert-manager"
+      service_account_name           = "cert-manager"
+      create_iam_resources_irsa      = true
+      enabled                        = false
+      iam_policy_override            = null
+      default_network_policy         = true
+      acme_email                     = "contact@acme.com"
+      acme_http01_enabled            = true
+      acme_http01_ingress_class      = "nginx"
+      acme_dns01_enabled             = true
+      cluster_issuer_assume_role_arn = ""
+      allowed_cidrs                  = ["0.0.0.0/0"]
+      csi_driver                     = false
+      name_prefix                    = "${var.cluster-name}-cert-manager"
     },
     var.cert-manager
   )
@@ -151,6 +152,7 @@ data "kubectl_path_documents" "cert-manager_cluster_issuers" {
     acme_http01_enabled       = local.cert-manager["acme_http01_enabled"]
     acme_http01_ingress_class = local.cert-manager["acme_http01_ingress_class"]
     acme_dns01_enabled        = local.cert-manager["acme_dns01_enabled"]
+    role_arn                  = local.cert-manager["cluster_issuer_assume_role_arn"]
   }
 }
 

--- a/modules/aws/templates/cert-manager-cluster-issuers.yaml.tpl
+++ b/modules/aws/templates/cert-manager-cluster-issuers.yaml.tpl
@@ -14,7 +14,9 @@ spec:
     - dns01:
         route53:
           region: '${aws_region}'
-          role: '${role}'
+          %{ if role_arn != "" }
+          role: '${role_arn}'
+          %{ endif }
     %{ endif }
     %{ if acme_http01_enabled }
     - http01:
@@ -42,7 +44,9 @@ spec:
     - dns01:
         route53:
           region: '${aws_region}'
-          role: '${role}'
+          %{ if role_arn != "" }
+          role: '${role_arn}'
+          %{ endif }
     %{ endif }
     %{ if acme_http01_enabled }
     - http01:

--- a/modules/aws/templates/cert-manager-cluster-issuers.yaml.tpl
+++ b/modules/aws/templates/cert-manager-cluster-issuers.yaml.tpl
@@ -14,6 +14,7 @@ spec:
     - dns01:
         route53:
           region: '${aws_region}'
+          role: '${role}'
     %{ endif }
     %{ if acme_http01_enabled }
     - http01:
@@ -41,6 +42,7 @@ spec:
     - dns01:
         route53:
           region: '${aws_region}'
+          role: '${role}'
     %{ endif }
     %{ if acme_http01_enabled }
     - http01:


### PR DESCRIPTION
# Add optional role parameter for cert-manager add-on

## Description

In case someone's doing certificates  cross-account, the following resources assigning/assuming roles and permissions are needed
For example, cert-manager needs to create a certificate in the local account using DNS challenge, but there's no Route53 zone in this account
In order to make the challenge, it needs to use the IRSA role which can assume the role in another account where the Route53 zone lives. In turn, this role from the account holding Route53 zone should allow being assumed by this IRSA role
But moreover, the IRSA role says that cert-manager **_can_** assume the role, but not giving the instruction to do this
That's why a custom ClusterIssuer resource is needed with the added role parameter which is currently not supported by the root module

### Checklist

- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/particuleio/terraform-kubernetes-addons/#doc-generation
