### PR TITLE
fix: add missing iam permissions on thanos in gcp

### DIFF
--- a/modules/google/thanos.tf
+++ b/modules/google/thanos.tf
@@ -294,6 +294,9 @@ module "thanos_bucket_iam" {
       "serviceAccount:${module.iam_assumable_sa_thanos-compactor[0].gcp_service_account_email}",
       "serviceAccount:${module.iam_assumable_sa_thanos-sg[0].gcp_service_account_email}",
     ]
+    "roles/storage.legacyBucketWriter" = [
+      "serviceAccount:${module.iam_assumable_sa_thanos-compactor[0].gcp_service_account_email}",
+    ]
   }
 }
 


### PR DESCRIPTION
# Add missing permission in thanos for GCP

## Description

thanos-compactor should have the permission to delete objects in the GCS bucket. In the module we have assigned the role `roles/storage.objectCreator` which doesn't have the `storage.objects.delete` permission.

```bash
level=info ts=2023-08-02T15:28:18.094440054Z caller=blocks_cleaner.go:44 msg="started cleaning of blocks marked for deletion"
level=warn ts=2023-08-02T15:28:18.13448783Z caller=intrumentation.go:67 msg="changing probe status" status=not-ready reason="cleaning marked blocks: delete block: delete 01H4Y0CT7GKNADK3ZSG6MFDXES/meta.json: googleapi: Error 403: thanos-compactor@xxxx-mainnet-0.iam.gserviceaccount.com does not have storage.objects.delete access to the Google Cloud Storage object. Permission 'storage.objects.delete' denied on resource (or it may not exist)., forbidden"
level=info ts=2023-08-02T15:28:18.13451885Z caller=http.go:91 service=http/server component=compact msg="internal server is shutting down" err="cleaning marked blocks: delete block: delete 01H4Y0CT7GKNADK3ZSG6MFDXES/meta.json: googleapi: Error 403: thanos-compactor@xxxx-mainnet-0.iam.gserviceaccount.com does not have storage.objects.delete access to the Google Cloud Storage object. Permission 'storage.objects.delete' denied on resource (or it may not exist)., forbidden"
level=info ts=2023-08-02T15:28:18.13457306Z caller=http.go:110 service=http/server component=compact msg="internal server is shutdown gracefully" err="cleaning marked blocks: delete block: delete 01H4Y0CT7GKNADK3ZSG6MFDXES/meta.json: googleapi: Error 403: thanos-compactor@xxxx-mainnet-0.iam.gserviceaccount.com does not have storage.objects.delete access to the Google Cloud Storage object. Permission 'storage.objects.delete' denied on resource (or it may not exist)., forbidden"
level=info ts=2023-08-02T15:28:18.1346248Z caller=intrumentation.go:81 msg="changing probe status" status=not-healthy reason="cleaning marked blocks: delete block: delete 01H4Y0CT7GKNADK3ZSG6MFDXES/meta.json: googleapi: Error 403: thanos-compactor@xxx-mainnet-0.iam.gserviceaccount.com does not have storage.objects.delete access to the Google Cloud Storage object. Permission 'storage.objects.delete' denied on resource (or it may not exist)., forbidden"
level=error ts=2023-08-02T15:28:18.1353006Z caller=compact.go:498 msg="retriable error" err="compaction: sync: BaseFetcher: iter bucket: context canceled"
level=error ts=2023-08-02T15:28:18.13549086Z caller=main.go:161 err="googleapi: Error 403: thanos-compactor@xxxx-mainnet-0.iam.gserviceaccount.com does not have storage.objects.delete access to the Google Cloud Storage object. Permission 'storage.objects.delete' denied on resource (or it may not exist)., forbidden\ndelete 01H4Y0CT7GKNADK3ZSG6MFDXES/meta.json\ngithub.com/thanos-io/thanos/pkg/block.Delete\n\t/bitnami/blacksmith-sandox/thanos-0.31.0/src/github.com/thanos-io/thanos/pkg/block/block.go:225\ngithub.com/thanos-io/thanos/pkg/compact.(*BlocksCleaner).DeleteMarkedBlocks\n\t/bitnami/blacksmith-sandox/thanos-0.31.0/src/github.com/thanos-io/thanos/pkg/compact/blocks_cleaner.go:49\nmain.runCompact.func6\n\t/bitnami/blacksmith-sandox/thanos-0.31.0/src/github.com/thanos-io/thanos/cmd/thanos/compact.go:413\nmain.runCompact.func14.1\n\t/bitnami/blacksmith-sandox/thanos-0.31.0/src/github.com/thanos-io/thanos/cmd/thanos/compact.go:560\ngithub.com/thanos-io/thanos/pkg/runutil.Repeat\n\t/bitnami/blacksmith-sandox/thanos-0.31.0/src/github.com/thanos-io/thanos/pkg/runutil/runutil.go:74\nmain.runCompact.func14\n\t/bitnami/blacksmith-sandox/thanos-0.31.0/src/github.com/thanos-io/thanos/cmd/thanos/compact.go:559\ngithub.com/oklog/run.(*Group).Run.func1\n\t/bitnami/blacksmith-sandox/thanos-0.31.0/pkg/mod/github.com/oklog/run@v1.1.0/group.go:38\nruntime.goexit\n\t/usr/local/go-1.19.10/src/runtime/asm_amd64.s:1594\ndelete block\ngithub.com/thanos-io/thanos/pkg/compact.(*BlocksCleaner).DeleteMarkedBlocks\n\t/bitnami/blacksmith-sandox/thanos-0.31.0/src/github.com/thanos-io/thanos/pkg/compact/blocks_cleaner.go:51\nmain.runCompact.func6\n\t/bitnami/blacksmith-sandox/thanos-0.31.0/src/github.com/thanos-io/thanos/cmd/thanos/compact.go:413\nmain.runCompact.func14.1\n\t/bitnami/blacksmith-sandox/thanos-0.31.0/src/github.com/thanos-io/thanos/cmd/thanos/compact.go:560\ngithub.com/thanos-io/thanos/pkg/runutil.Repeat\n\t/bitnami/blacksmith-sandox/thanos-0.31.0/src/github.com/thanos-io/thanos/pkg/runutil/runutil.go:74\nmain.runCompact.func14\n\t/bitnami/blacksmith-sandox/thanos-0.31.0/src/github.com/thanos-io/thanos/cmd/thanos/compact.go:559\ngithub.com/oklog/run.(*Group).Run.func1\n\t/bitnami/blacksmith-sandox/thanos-0.31.0/pkg/mod/github.com/oklog/run@v1.1.0/group.go:38\nruntime.goexit\n\t/usr/local/go-1.19.10/src/runtime/asm_amd64.s:1594\ncleaning marked blocks\nmain.runCompact.func6\n\t/bitnami/blacksmith-sandox/thanos-0.31.0/src/github.com/thanos-io/thanos/cmd/thanos/compact.go:414\nmain.runCompact.func14.1\n\t/bitnami/blacksmith-sandox/thanos-0.31.0/src/github.com/thanos-io/thanos/cmd/thanos/compact.go:560\ngithub.com/thanos-io/thanos/pkg/runutil.Repeat\n\t/bitnami/blacksmith-sandox/thanos-0.31.0/src/github.com/thanos-io/thanos/pkg/runutil/runutil.go:74\nmain.runCompact.func14\n\t/bitnami/blacksmith-sandox/thanos-0.31.0/src/github.com/thanos-io/thanos/cmd/thanos/compact.go:559\ngithub.com/oklog/run.(*Group).Run.func1\n\t/bitnami/blacksmith-sandox/thanos-0.31.0/pkg/mod/github.com/oklog/run@v1.1.0/group.go:38\nruntime.goexit\n\t/usr/local/go-1.19.10/src/runtime/asm_amd64.s:1594\ncompact command failed\nmain.main\n\t/bitnami/blacksmith-sandox/thanos-0.31.0/src/github.com/thanos-io/thanos/cmd/thanos/main.go:161\nruntime.main\n\t/usr/local/go-1.19.10/src/runtime/proc.go:250\nruntime.goexit\n\t/usr/local/go-1.19.10/src/runtime/asm_amd64.s:1594"
```

To fix this issue, I've added the role `roles/storage.legacyBucketWriter` to the `thanos-compactor` service account

### Checklist

- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/particuleio/terraform-kubernetes-addons/#doc-generation
