### PR TITLE
fix(google): disable coredns monitoring by default on GKE

### DIFF
--- a/modules/google/kube-prometheus.tf
+++ b/modules/google/kube-prometheus.tf
@@ -42,6 +42,8 @@ kubeControllerManager:
   enabled: false
 kubeEtcd:
   enabled: false
+coreDns:
+  enabled: false
 grafana:
   sidecar:
     dashboards:


### PR DESCRIPTION
Signed-off-by: Kevin Lefevre <kevin@particule.io>

# Pull request title

## Description

Please explain the changes you made here and link to any relevant issues.

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/particuleio/terraform-kubernetes-addons/#doc-generation
