### PR TITLE
feat: Add option to disable thanos dashboards in kube-prometheus-stack

### DIFF
--- a/modules/aws/kube-prometheus.tf
+++ b/modules/aws/kube-prometheus.tf
@@ -14,6 +14,7 @@ locals {
       thanos_create_iam_resources_irsa  = true
       thanos_iam_policy_override        = null
       thanos_sidecar_enabled            = false
+      thanos_dashboard_enabled          = true
       thanos_create_bucket              = true
       thanos_bucket                     = "thanos-store-${var.cluster-name}"
       thanos_bucket_force_destroy       = false
@@ -482,7 +483,7 @@ resource "helm_release" "kube-prometheus-stack" {
     local.cert-manager["enabled"] ? local.values_dashboard_cert-manager : null,
     local.cluster-autoscaler["enabled"] ? local.values_dashboard_cluster-autoscaler : null,
     local.ingress-nginx["enabled"] ? local.values_dashboard_ingress-nginx : null,
-    local.thanos["enabled"] ? local.values_dashboard_thanos : null,
+    local.thanos["enabled"] && local.kube-prometheus-stack["thanos_dashboard_enabled"] ? local.values_dashboard_thanos : null,
     local.values_dashboard_node_exporter,
     local.kube-prometheus-stack["thanos_sidecar_enabled"] ? local.values_thanos_sidecar : null,
     local.kube-prometheus-stack["thanos_sidecar_enabled"] ? local.values_grafana_ds : null,

--- a/modules/google/kube-prometheus.tf
+++ b/modules/google/kube-prometheus.tf
@@ -15,6 +15,7 @@ locals {
       thanos_create_iam_resources           = true
       thanos_iam_policy_override            = null
       thanos_sidecar_enabled                = false
+      thanos_dashboard_enabled              = true
       thanos_create_bucket                  = true
       thanos_bucket                         = "thanos-store-${var.cluster-name}"
       thanos_bucket_force_destroy           = false
@@ -386,7 +387,7 @@ resource "helm_release" "kube-prometheus-stack" {
   values = compact([
     local.values_kube-prometheus-stack,
     local.ingress-nginx["enabled"] ? local.values_dashboard_ingress-nginx : null,
-    local.thanos["enabled"] ? local.values_dashboard_thanos : null,
+    local.thanos["enabled"] && local.kube-prometheus-stack["thanos_dashboard_enabled"] ? local.values_dashboard_thanos : null,
     local.values_dashboard_node_exporter,
     local.kube-prometheus-stack["thanos_sidecar_enabled"] ? local.values_thanos_sidecar : null,
     local.kube-prometheus-stack["thanos_sidecar_enabled"] ? local.values_grafana_ds : null,

--- a/modules/scaleway/kube-prometheus.tf
+++ b/modules/scaleway/kube-prometheus.tf
@@ -2,23 +2,24 @@ locals {
   kube-prometheus-stack = merge(
     local.helm_defaults,
     {
-      name                    = local.helm_dependencies[index(local.helm_dependencies.*.name, "kube-prometheus-stack")].name
-      chart                   = local.helm_dependencies[index(local.helm_dependencies.*.name, "kube-prometheus-stack")].name
-      repository              = local.helm_dependencies[index(local.helm_dependencies.*.name, "kube-prometheus-stack")].repository
-      chart_version           = local.helm_dependencies[index(local.helm_dependencies.*.name, "kube-prometheus-stack")].version
-      namespace               = "monitoring"
-      thanos_sidecar_enabled  = false
-      thanos_create_bucket    = true
-      thanos_bucket           = "thanos-store-${var.cluster-name}"
-      thanos_bucket_region    = local.scaleway["region"]
-      thanos_store_config     = null
-      thanos_version          = "v0.31.0"
-      enabled                 = false
-      allowed_cidrs           = ["0.0.0.0/0"]
-      default_network_policy  = true
-      default_global_requests = false
-      default_global_limits   = false
-      manage_crds             = true
+      name                     = local.helm_dependencies[index(local.helm_dependencies.*.name, "kube-prometheus-stack")].name
+      chart                    = local.helm_dependencies[index(local.helm_dependencies.*.name, "kube-prometheus-stack")].name
+      repository               = local.helm_dependencies[index(local.helm_dependencies.*.name, "kube-prometheus-stack")].repository
+      chart_version            = local.helm_dependencies[index(local.helm_dependencies.*.name, "kube-prometheus-stack")].version
+      namespace                = "monitoring"
+      thanos_sidecar_enabled   = false
+      thanos_dashboard_enabled = true
+      thanos_create_bucket     = true
+      thanos_bucket            = "thanos-store-${var.cluster-name}"
+      thanos_bucket_region     = local.scaleway["region"]
+      thanos_store_config      = null
+      thanos_version           = "v0.31.0"
+      enabled                  = false
+      allowed_cidrs            = ["0.0.0.0/0"]
+      default_network_policy   = true
+      default_global_requests  = false
+      default_global_limits    = false
+      manage_crds              = true
     },
     var.kube-prometheus-stack
   )
@@ -320,7 +321,7 @@ resource "helm_release" "kube-prometheus-stack" {
     local.cert-manager["enabled"] ? local.values_dashboard_cert-manager : null,
     local.values_dashboard_cluster-autoscaler,
     local.ingress-nginx["enabled"] ? local.values_dashboard_ingress-nginx : null,
-    local.thanos["enabled"] ? local.values_dashboard_thanos : null,
+    local.thanos["enabled"] && local.kube-prometheus-stack["thanos_dashboard_enabled"] ? local.values_dashboard_thanos : null,
     local.values_dashboard_node_exporter,
     local.kube-prometheus-stack["thanos_sidecar_enabled"] ? local.values_thanos_sidecar : null,
     local.kube-prometheus-stack["thanos_sidecar_enabled"] ? local.values_grafana_ds : null,


### PR DESCRIPTION
Add new local value `thanos_sidecar_enabled` and replace the ternary expression within helm_release.kube-prometheus-stack.values from `local.thanos["enabled"] ? local.values_dashboard_thanos : null,` to `local.thanos["enabled"] && local.kube-prometheus-stack["thanos_dashboard_enabled"] ? local.values_dashboard_thanos : null`

This change adds the ability to use Thanos but optionally enable or disable the built-in Thanos dashboards available at `locals.values_dashboard_thanos`

The changes are made only in aws, google and scaleway kube-prometheus.tf. The root and azure modules do not have Thanos.

I have tested the change locally and on the project where we're utilizing the terraform-kubernetes-addons module and there were no issues. Pre-commit tests have all passed.

Let me know if I need to adjust the PR.

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/particuleio/terraform-kubernetes-addons/#doc-generation
