### PR TITLE
fix(velero): drop the CSI plugin

### DIFF
--- a/modules/aws/velero.tf
+++ b/modules/aws/velero.tf
@@ -56,12 +56,6 @@ initContainers:
      volumeMounts:
        - mountPath: /target
          name: plugins
-   - name: velero-plugin-for-csi
-     image: velero/velero-plugin-for-csi:v0.7.1
-     imagePullPolicy: IfNotPresent
-     volumeMounts:
-       - mountPath: /target
-         name: plugins
 VALUES
 
 }


### PR DESCRIPTION
Since https://github.com/particuleio/terraform-kubernetes-addons/commit/3ae3e1768531671cea6d5a7af475d49931a615ce, we upgraded the Velero chart to v7 but this requires us to drop the CSI plugin. Without this change, velero is crashlooping due to a duplicate plugin registration

```
An error occurred: unable to register plugin (kind=BackupItemActionV2, name=velero.io/csi-pvc-backupper, command=/plugins/velero-plugin-for-csi) because another plugin is already registered for this kind and name (command=/velero)
```

Ref: https://github.com/vmware-tanzu/helm-charts/blob/main/charts/velero/README.md#upgrading-to-700
