### PR TITLE
feat: add a new velero module on scaleway

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ No modules.
 | <a name="input_thanos-tls-querier"></a> [thanos-tls-querier](#input\_thanos-tls-querier) | Customize thanos chart, see `thanos.tf` for supported values | `any` | `{}` | no |
 | <a name="input_tigera-operator"></a> [tigera-operator](#input\_tigera-operator) | Customize tigera-operator chart, see `tigera-operator.tf` for supported values | `any` | `{}` | no |
 | <a name="input_traefik"></a> [traefik](#input\_traefik) | Customize traefik chart, see `traefik.tf` for supported values | `any` | `{}` | no |
+| <a name="input_velero"></a> [velero](#input\_velero) | Customize velero chart, see `velero.tf` for supported values | `any` | `{}` | no |
 | <a name="input_victoria-metrics-k8s-stack"></a> [victoria-metrics-k8s-stack](#input\_victoria-metrics-k8s-stack) | Customize Victoria Metrics chart, see `victoria-metrics-k8s-stack.tf` for supported values | `any` | `{}` | no |
 
 ## Outputs

--- a/modules/aws/variables-aws.tf
+++ b/modules/aws/variables-aws.tf
@@ -82,12 +82,6 @@ variable "tags" {
   default     = {}
 }
 
-variable "velero" {
-  description = "Customize velero chart, see `velero.tf` for supported values"
-  type        = any
-  default     = {}
-}
-
 variable "yet-another-cloudwatch-exporter" {
   description = "Customize yet-another-cloudwatch-exporter chart, see `yet-another-cloudwatch-exporter.tf` for supported values"
   type        = any

--- a/modules/azure/README.md
+++ b/modules/azure/README.md
@@ -223,6 +223,7 @@ No modules.
 | <a name="input_thanos-tls-querier"></a> [thanos-tls-querier](#input\_thanos-tls-querier) | Customize thanos chart, see `thanos.tf` for supported values | `any` | `{}` | no |
 | <a name="input_tigera-operator"></a> [tigera-operator](#input\_tigera-operator) | Customize tigera-operator chart, see `tigera-operator.tf` for supported values | `any` | `{}` | no |
 | <a name="input_traefik"></a> [traefik](#input\_traefik) | Customize traefik chart, see `traefik.tf` for supported values | `any` | `{}` | no |
+| <a name="input_velero"></a> [velero](#input\_velero) | Customize velero chart, see `velero.tf` for supported values | `any` | `{}` | no |
 | <a name="input_victoria-metrics-k8s-stack"></a> [victoria-metrics-k8s-stack](#input\_victoria-metrics-k8s-stack) | Customize Victoria Metrics chart, see `victoria-metrics-k8s-stack.tf` for supported values | `any` | `{}` | no |
 
 ## Outputs

--- a/modules/google/variables-google.tf
+++ b/modules/google/variables-google.tf
@@ -33,9 +33,3 @@ variable "tags" {
   type        = map(any)
   default     = {}
 }
-
-variable "velero" {
-  description = "Customize velero chart, see `velero.tf` for supported values"
-  type        = any
-  default     = {}
-}

--- a/modules/scaleway/README.md
+++ b/modules/scaleway/README.md
@@ -82,6 +82,7 @@ No modules.
 | [helm_release.thanos-storegateway](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.thanos-tls-querier](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.traefik](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [helm_release.velero](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.victoria-metrics-k8s-stack](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [kubectl_manifest.cert-manager_cluster_issuers](https://registry.terraform.io/providers/alekc/kubectl/latest/docs/resources/manifest) | resource |
 | [kubectl_manifest.csi-external-snapshotter](https://registry.terraform.io/providers/alekc/kubectl/latest/docs/resources/manifest) | resource |
@@ -111,6 +112,7 @@ No modules.
 | [kubernetes_namespace.sealed-secrets](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 | [kubernetes_namespace.thanos](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 | [kubernetes_namespace.traefik](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
+| [kubernetes_namespace.velero](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 | [kubernetes_namespace.victoria-metrics-k8s-stack](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 | [kubernetes_network_policy.admiralty_allow_namespace](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.admiralty_default_deny](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
@@ -168,6 +170,9 @@ No modules.
 | [kubernetes_network_policy.traefik_allow_monitoring](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.traefik_allow_namespace](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.traefik_default_deny](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
+| [kubernetes_network_policy.velero_allow_monitoring](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
+| [kubernetes_network_policy.velero_allow_namespace](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
+| [kubernetes_network_policy.velero_default_deny](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.victoria-metrics-k8s-stack_allow_control_plane](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.victoria-metrics-k8s-stack_allow_ingress](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.victoria-metrics-k8s-stack_allow_namespace](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
@@ -186,6 +191,11 @@ No modules.
 | [scaleway_object_bucket.kube-prometheus-stack_thanos_bucket](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/resources/object_bucket) | resource |
 | [scaleway_object_bucket.loki_bucket](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/resources/object_bucket) | resource |
 | [scaleway_object_bucket.thanos_bucket](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/resources/object_bucket) | resource |
+| [scaleway_object_bucket.velero_bucket](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/resources/object_bucket) | resource |
+| [scaleway_object_bucket_acl.kube-prometheus-stack_bucket_acl](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/resources/object_bucket_acl) | resource |
+| [scaleway_object_bucket_acl.loki_bucket_acl](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/resources/object_bucket_acl) | resource |
+| [scaleway_object_bucket_acl.thanos_bucket_acl](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/resources/object_bucket_acl) | resource |
+| [scaleway_object_bucket_acl.velero_bucket_acl](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/resources/object_bucket_acl) | resource |
 | [time_sleep.cert-manager_sleep](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [tls_cert_request.promtail-csr](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/cert_request) | resource |
 | [tls_cert_request.thanos-tls-querier-cert-csr](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/cert_request) | resource |
@@ -250,12 +260,14 @@ No modules.
 | <a name="input_scaleway"></a> [scaleway](#input\_scaleway) | Scaleway provider customization | `any` | `{}` | no |
 | <a name="input_sealed-secrets"></a> [sealed-secrets](#input\_sealed-secrets) | Customize sealed-secrets chart, see `sealed-secrets.tf` for supported values | `any` | `{}` | no |
 | <a name="input_secrets-store-csi-driver"></a> [secrets-store-csi-driver](#input\_secrets-store-csi-driver) | Customize secrets-store-csi-driver chart, see `secrets-store-csi-driver.tf` for supported values | `any` | `{}` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Map of tags for Scaleway resources | `map(any)` | `{}` | no |
 | <a name="input_thanos"></a> [thanos](#input\_thanos) | Customize thanos chart, see `thanos.tf` for supported values | `any` | `{}` | no |
 | <a name="input_thanos-memcached"></a> [thanos-memcached](#input\_thanos-memcached) | Customize thanos chart, see `thanos.tf` for supported values | `any` | `{}` | no |
 | <a name="input_thanos-storegateway"></a> [thanos-storegateway](#input\_thanos-storegateway) | Customize thanos chart, see `thanos.tf` for supported values | `any` | `{}` | no |
 | <a name="input_thanos-tls-querier"></a> [thanos-tls-querier](#input\_thanos-tls-querier) | Customize thanos chart, see `thanos.tf` for supported values | `any` | `{}` | no |
 | <a name="input_tigera-operator"></a> [tigera-operator](#input\_tigera-operator) | Customize tigera-operator chart, see `tigera-operator.tf` for supported values | `any` | `{}` | no |
 | <a name="input_traefik"></a> [traefik](#input\_traefik) | Customize traefik chart, see `traefik.tf` for supported values | `any` | `{}` | no |
+| <a name="input_velero"></a> [velero](#input\_velero) | Customize velero chart, see `velero.tf` for supported values | `any` | `{}` | no |
 | <a name="input_victoria-metrics-k8s-stack"></a> [victoria-metrics-k8s-stack](#input\_victoria-metrics-k8s-stack) | Customize Victoria Metrics chart, see `victoria-metrics-k8s-stack.tf` for supported values | `any` | `{}` | no |
 
 ## Outputs

--- a/modules/scaleway/kube-prometheus.tf
+++ b/modules/scaleway/kube-prometheus.tf
@@ -288,7 +288,12 @@ resource "kubernetes_namespace" "kube-prometheus-stack" {
 resource "scaleway_object_bucket" "kube-prometheus-stack_thanos_bucket" {
   count = local.kube-prometheus-stack["enabled"] && local.kube-prometheus-stack["thanos_sidecar_enabled"] && local.kube-prometheus-stack["thanos_create_bucket"] ? 1 : 0
   name  = local.kube-prometheus-stack["thanos_bucket"]
-  acl   = "private"
+}
+
+resource "scaleway_object_bucket_acl" "kube-prometheus-stack_bucket_acl" {
+  count  = local.kube-prometheus-stack["enabled"] && local.kube-prometheus-stack["thanos_sidecar_enabled"] && local.kube-prometheus-stack["thanos_create_bucket"] ? 1 : 0
+  bucket = scaleway_object_bucket.kube-prometheus-stack_thanos_bucket.0.id
+  acl    = "private"
 }
 
 resource "random_string" "grafana_password" {

--- a/modules/scaleway/locals-scaleway.tf
+++ b/modules/scaleway/locals-scaleway.tf
@@ -12,7 +12,7 @@ locals {
     var.scaleway
   )
 
-  tags          = var.tags
+  tags = var.tags
 
 
 }

--- a/modules/scaleway/locals-scaleway.tf
+++ b/modules/scaleway/locals-scaleway.tf
@@ -12,4 +12,7 @@ locals {
     var.scaleway
   )
 
+  tags          = var.tags
+
+
 }

--- a/modules/scaleway/loki-stack.tf
+++ b/modules/scaleway/loki-stack.tf
@@ -233,7 +233,12 @@ resource "kubernetes_secret" "loki-stack-ca" {
 resource "scaleway_object_bucket" "loki_bucket" {
   count = local.loki-stack["enabled"] && local.loki-stack["create_bucket"] ? 1 : 0
   name  = local.loki-stack["bucket"]
-  acl   = "private"
+}
+
+resource "scaleway_object_bucket_acl" "loki_bucket_acl" {
+  count  = local.loki-stack["enabled"] && local.loki-stack["create_bucket"] ? 1 : 0
+  bucket = scaleway_object_bucket.loki_bucket.0.id
+  acl    = "private"
 }
 
 resource "tls_private_key" "promtail-key" {

--- a/modules/scaleway/thanos.tf
+++ b/modules/scaleway/thanos.tf
@@ -211,7 +211,12 @@ locals {
 resource "scaleway_object_bucket" "thanos_bucket" {
   count = local.thanos["enabled"] && local.thanos["create_bucket"] ? 1 : 0
   name  = local.thanos["bucket"]
-  acl   = "private"
+}
+
+resource "scaleway_object_bucket_acl" "thanos_bucket_acl" {
+  count  = local.thanos["enabled"] && local.thanos["create_bucket"] ? 1 : 0
+  bucket = scaleway_object_bucket.thanos_bucket.0.id
+  acl    = "private"
 }
 
 resource "kubernetes_namespace" "thanos" {

--- a/modules/scaleway/variables-scaleway.tf
+++ b/modules/scaleway/variables-scaleway.tf
@@ -15,3 +15,9 @@ variable "cert-manager_scaleway_webhook_dns" {
   type        = any
   default     = {}
 }
+
+variable "tags" {
+  description = "Map of tags for Scaleway resources"
+  type        = map(any)
+  default     = {}
+}

--- a/modules/scaleway/velero.tf
+++ b/modules/scaleway/velero.tf
@@ -2,19 +2,19 @@ locals {
   velero = merge(
     local.helm_defaults,
     {
-      name                      = local.helm_dependencies[index(local.helm_dependencies.*.name, "velero")].name
-      chart                     = local.helm_dependencies[index(local.helm_dependencies.*.name, "velero")].name
-      repository                = local.helm_dependencies[index(local.helm_dependencies.*.name, "velero")].repository
-      chart_version             = local.helm_dependencies[index(local.helm_dependencies.*.name, "velero")].version
-      namespace                 = "velero"
-      service_account_name      = "velero"
-      enabled                   = false
-      create_bucket             = true
-      bucket                    = "${var.cluster-name}-velero"
-      bucket_force_destroy      = false
-      default_network_policy    = true
-      name_prefix               = "${var.cluster-name}-velero"
-      secret_name               = "velero-scaleway-credentials"
+      name                   = local.helm_dependencies[index(local.helm_dependencies.*.name, "velero")].name
+      chart                  = local.helm_dependencies[index(local.helm_dependencies.*.name, "velero")].name
+      repository             = local.helm_dependencies[index(local.helm_dependencies.*.name, "velero")].repository
+      chart_version          = local.helm_dependencies[index(local.helm_dependencies.*.name, "velero")].version
+      namespace              = "velero"
+      service_account_name   = "velero"
+      enabled                = false
+      create_bucket          = true
+      bucket                 = "${var.cluster-name}-velero"
+      bucket_force_destroy   = false
+      default_network_policy = true
+      name_prefix            = "${var.cluster-name}-velero"
+      secret_name            = "velero-scaleway-credentials"
     },
     var.velero
   )
@@ -58,7 +58,7 @@ VALUES
 }
 
 resource "scaleway_object_bucket" "velero_bucket" {
-  count = local.velero.enabled && local.velero.create_bucket  ? 1 : 0
+  count = local.velero.enabled && local.velero.create_bucket ? 1 : 0
   name  = local.velero.bucket
 
   versioning {
@@ -71,9 +71,9 @@ resource "scaleway_object_bucket" "velero_bucket" {
 }
 
 resource "scaleway_object_bucket_acl" "velero_bucket_acl" {
-  count = local.velero.enabled && local.velero.create_bucket  ? 1 : 0
+  count  = local.velero.enabled && local.velero.create_bucket ? 1 : 0
   bucket = scaleway_object_bucket.velero_bucket.0.id
-  acl = "private"
+  acl    = "private"
 }
 
 resource "kubernetes_namespace" "velero" {

--- a/modules/scaleway/velero.tf
+++ b/modules/scaleway/velero.tf
@@ -1,0 +1,193 @@
+locals {
+  velero = merge(
+    local.helm_defaults,
+    {
+      name                      = local.helm_dependencies[index(local.helm_dependencies.*.name, "velero")].name
+      chart                     = local.helm_dependencies[index(local.helm_dependencies.*.name, "velero")].name
+      repository                = local.helm_dependencies[index(local.helm_dependencies.*.name, "velero")].repository
+      chart_version             = local.helm_dependencies[index(local.helm_dependencies.*.name, "velero")].version
+      namespace                 = "velero"
+      service_account_name      = "velero"
+      enabled                   = false
+      create_bucket             = true
+      bucket                    = "${var.cluster-name}-velero"
+      bucket_force_destroy      = false
+      default_network_policy    = true
+      name_prefix               = "${var.cluster-name}-velero"
+      secret_name               = "velero-scaleway-credentials"
+    },
+    var.velero
+  )
+
+  values_velero = <<VALUES
+metrics:
+  serviceMonitor:
+    enabled: ${local.kube-prometheus-stack.enabled || local.victoria-metrics-k8s-stack.enabled}
+configuration:
+  namespace: ${local.velero.namespace}
+  backupStorageLocation:
+    - name: aws
+      provider: aws
+      bucket: ${local.velero.bucket}
+      default: true
+deployNodeAgent: true
+nodeAgent:
+  tolerations:
+    - effect: NoSchedule
+      operator: Exists
+    - key: CriticalAddonsOnly
+      operator: Exists
+    - effect: NoExecute
+      operator: Exists
+snapshotsEnabled: false
+serviceAccount:
+  server:
+    name: ${local.velero.service_account_name}
+priorityClassName: ${local.priority-class-ds.create ? kubernetes_priority_class.kubernetes_addons_ds[0].metadata[0].name : ""}
+credentials:
+  useSecret: true
+  existingSecret: ${local.velero.secret_name}
+initContainers:
+   - name: velero-plugin-for-aws
+     image: velero/velero-plugin-for-aws:v1.10.1
+     imagePullPolicy: IfNotPresent
+     volumeMounts:
+       - mountPath: /target
+         name: plugins
+VALUES
+}
+
+resource "scaleway_object_bucket" "velero_bucket" {
+  count = local.velero.enabled && local.velero.create_bucket  ? 1 : 0
+  name  = local.velero.bucket
+
+  versioning {
+    enabled = true
+  }
+
+  force_destroy = local.velero.bucket_force_destroy
+
+  tags = local.tags
+}
+
+resource "scaleway_object_bucket_acl" "velero_bucket_acl" {
+  count = local.velero.enabled && local.velero.create_bucket  ? 1 : 0
+  bucket = scaleway_object_bucket.velero_bucket.0.id
+  acl = "private"
+}
+
+resource "kubernetes_namespace" "velero" {
+  count = local.velero.enabled ? 1 : 0
+
+  metadata {
+    labels = {
+      name = local.velero.namespace
+    }
+
+    name = local.velero.namespace
+  }
+}
+
+resource "helm_release" "velero" {
+  count                 = local.velero.enabled ? 1 : 0
+  repository            = local.velero.repository
+  name                  = local.velero.name
+  chart                 = local.velero.chart
+  version               = local.velero.chart_version
+  timeout               = local.velero.timeout
+  force_update          = local.velero.force_update
+  recreate_pods         = local.velero.recreate_pods
+  wait                  = local.velero.wait
+  atomic                = local.velero.atomic
+  cleanup_on_fail       = local.velero.cleanup_on_fail
+  dependency_update     = local.velero.dependency_update
+  disable_crd_hooks     = local.velero.disable_crd_hooks
+  disable_webhooks      = local.velero.disable_webhooks
+  render_subchart_notes = local.velero.render_subchart_notes
+  replace               = local.velero.replace
+  reset_values          = local.velero.reset_values
+  reuse_values          = local.velero.reuse_values
+  skip_crds             = local.velero.skip_crds
+  verify                = local.velero.verify
+  values = compact([
+    local.values_velero,
+    local.velero.extra_values
+  ])
+  namespace = kubernetes_namespace.velero.*.metadata.0.name[count.index]
+
+  depends_on = [
+    kubectl_manifest.prometheus-operator_crds
+  ]
+}
+
+resource "kubernetes_network_policy" "velero_default_deny" {
+  count = local.velero.enabled && local.velero.default_network_policy ? 1 : 0
+
+  metadata {
+    name      = "${kubernetes_namespace.velero.*.metadata.0.name[count.index]}-default-deny"
+    namespace = kubernetes_namespace.velero.*.metadata.0.name[count.index]
+  }
+
+  spec {
+    pod_selector {
+    }
+    policy_types = ["Ingress"]
+  }
+}
+
+resource "kubernetes_network_policy" "velero_allow_namespace" {
+  count = local.velero.enabled && local.velero.default_network_policy ? 1 : 0
+
+  metadata {
+    name      = "${kubernetes_namespace.velero.*.metadata.0.name[count.index]}-allow-namespace"
+    namespace = kubernetes_namespace.velero.*.metadata.0.name[count.index]
+  }
+
+  spec {
+    pod_selector {
+    }
+
+    ingress {
+      from {
+        namespace_selector {
+          match_labels = {
+            name = kubernetes_namespace.velero.*.metadata.0.name[count.index]
+          }
+        }
+      }
+    }
+
+    policy_types = ["Ingress"]
+  }
+}
+
+resource "kubernetes_network_policy" "velero_allow_monitoring" {
+  count = local.velero.enabled && local.velero.default_network_policy ? 1 : 0
+
+  metadata {
+    name      = "${kubernetes_namespace.velero.*.metadata.0.name[count.index]}-allow-monitoring"
+    namespace = kubernetes_namespace.velero.*.metadata.0.name[count.index]
+  }
+
+  spec {
+    pod_selector {
+    }
+
+    ingress {
+      ports {
+        port     = "8085"
+        protocol = "TCP"
+      }
+
+      from {
+        namespace_selector {
+          match_labels = {
+            "${local.labels_prefix}/component" = "monitoring"
+          }
+        }
+      }
+    }
+
+    policy_types = ["Ingress"]
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -231,3 +231,9 @@ variable "reloader" {
   type        = any
   default     = {}
 }
+
+variable "velero" {
+  description = "Customize velero chart, see `velero.tf` for supported values"
+  type        = any
+  default     = {}
+}


### PR DESCRIPTION
# 🚀 Add new Velero module on Scaleway & fix deprecated ACL attribute on Scaleway buckets

📝 Description
This PR introduces two key changes:

🚀 Feature: New Velero module on Scaleway
Implemented a Velero module to manage backup and recovery solutions on Scaleway.

🛠 Fix: Deprecated ACL attribute on Scaleway buckets
Replaced the deprecated `acl` attribute in Scaleway buckets with the new and recommended terraform resource.

[Deprecation notice](https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/resources/object_bucket#acl)

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/particuleio/terraform-kubernetes-addons/#doc-generation
