### PR TITLE
feat(google): add velero support

### DIFF
--- a/modules/google/README.md
+++ b/modules/google/README.md
@@ -66,6 +66,7 @@ Provides various Kubernetes addons that are often used on Kubernetes with GCP
 | <a name="module_thanos-storegateway_bucket_iam"></a> [thanos-storegateway\_bucket\_iam](#module\_thanos-storegateway\_bucket\_iam) | terraform-google-modules/iam/google//modules/storage_buckets_iam | ~> 8.0 |
 | <a name="module_thanos_bucket"></a> [thanos\_bucket](#module\_thanos\_bucket) | terraform-google-modules/cloud-storage/google//modules/simple_bucket | ~> 6.0 |
 | <a name="module_thanos_kms_bucket"></a> [thanos\_kms\_bucket](#module\_thanos\_kms\_bucket) | terraform-google-modules/kms/google | ~> 3.0 |
+| <a name="module_velero_bucket"></a> [velero\_bucket](#module\_velero\_bucket) | github.com/terraform-google-modules/terraform-google-cloud-storage//modules/simple_bucket | v6.1.0 |
 
 ## Resources
 
@@ -77,6 +78,10 @@ Provides various Kubernetes addons that are often used on Kubernetes with GCP
 | [github_repository_deploy_key.main](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_deploy_key) | resource |
 | [google_dns_managed_zone_iam_member.cert_manager_cloud_dns_iam_permissions](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_managed_zone_iam_member) | resource |
 | [google_dns_managed_zone_iam_member.external_dns_cloud_dns_iam_permissions](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_managed_zone_iam_member) | resource |
+| [google_project_iam_custom_role.velero](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
+| [google_project_iam_member.velero](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_service_account.velero](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+| [google_service_account_iam_policy.admin-account-iam](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_policy) | resource |
 | [google_storage_bucket_iam_member.kube_prometheus_stack_thanos_bucket_objectAdmin_iam_permission](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
 | [google_storage_bucket_iam_member.kube_prometheus_stack_thanos_bucket_objectViewer_iam_permission](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
 | [google_storage_bucket_iam_member.thanos_compactor_gcs_iam_legacyBucketWriter_permissions](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
@@ -111,6 +116,7 @@ Provides various Kubernetes addons that are often used on Kubernetes with GCP
 | [helm_release.thanos-storegateway](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.thanos-tls-querier](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.traefik](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [helm_release.velero](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.victoria-metrics-k8s-stack](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [kubectl_manifest.cert-manager_cluster_issuers](https://registry.terraform.io/providers/alekc/kubectl/latest/docs/resources/manifest) | resource |
 | [kubectl_manifest.ip_masq_agent](https://registry.terraform.io/providers/alekc/kubectl/latest/docs/resources/manifest) | resource |
@@ -118,6 +124,7 @@ Provides various Kubernetes addons that are often used on Kubernetes with GCP
 | [kubectl_manifest.linkerd-viz](https://registry.terraform.io/providers/alekc/kubectl/latest/docs/resources/manifest) | resource |
 | [kubectl_manifest.prometheus-operator_crds](https://registry.terraform.io/providers/alekc/kubectl/latest/docs/resources/manifest) | resource |
 | [kubernetes_config_map.loki-stack_grafana_ds](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map) | resource |
+| [kubernetes_manifest.velero_snapshot_class](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 | [kubernetes_namespace.admiralty](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 | [kubernetes_namespace.cert-manager](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 | [kubernetes_namespace.external-dns](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
@@ -139,6 +146,7 @@ Provides various Kubernetes addons that are often used on Kubernetes with GCP
 | [kubernetes_namespace.secrets-store-csi-driver](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 | [kubernetes_namespace.thanos](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 | [kubernetes_namespace.traefik](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
+| [kubernetes_namespace.velero](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 | [kubernetes_namespace.victoria-metrics-k8s-stack](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 | [kubernetes_network_policy.admiralty_allow_namespace](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.admiralty_default_deny](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
@@ -193,6 +201,9 @@ Provides various Kubernetes addons that are often used on Kubernetes with GCP
 | [kubernetes_network_policy.traefik_allow_monitoring](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.traefik_allow_namespace](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.traefik_default_deny](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
+| [kubernetes_network_policy.velero_allow_monitoring](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
+| [kubernetes_network_policy.velero_allow_namespace](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
+| [kubernetes_network_policy.velero_default_deny](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.victoria-metrics-k8s-stack_allow_control_plane](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.victoria-metrics-k8s-stack_allow_ingress](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
 | [kubernetes_network_policy.victoria-metrics-k8s-stack_allow_namespace](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
@@ -223,6 +234,7 @@ Provides various Kubernetes addons that are often used on Kubernetes with GCP
 | [tls_self_signed_cert.thanos-tls-querier-ca-cert](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/self_signed_cert) | resource |
 | [tls_self_signed_cert.webhook_issuer_tls](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/self_signed_cert) | resource |
 | [github_repository.main](https://registry.terraform.io/providers/integrations/github/latest/docs/data-sources/repository) | data source |
+| [google_iam_policy.velero](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/iam_policy) | data source |
 | [google_project.current](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |
 | [http_http.prometheus-operator_crds](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
 | [http_http.prometheus-operator_version](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |

--- a/modules/google/velero.tf
+++ b/modules/google/velero.tf
@@ -1,0 +1,273 @@
+locals {
+  velero = merge(
+    local.helm_defaults,
+    {
+      name                    = local.helm_dependencies[index(local.helm_dependencies.*.name, "velero")].name
+      chart                   = local.helm_dependencies[index(local.helm_dependencies.*.name, "velero")].name
+      repository              = local.helm_dependencies[index(local.helm_dependencies.*.name, "velero")].repository
+      chart_version           = local.helm_dependencies[index(local.helm_dependencies.*.name, "velero")].version
+      namespace               = "velero"
+      service_account_name    = "velero"
+      enabled                 = false
+      create_iam_account      = true
+      iam_account_name        = "gke-${substr(var.cluster-name, 0, 18)}-velero"
+      create_bucket           = true
+      bucket                  = "${var.cluster-name}-velero"
+      bucket_location         = "eu"
+      bucket_force_destroy    = false
+      bucket_versioning       = false
+      allowed_cidrs           = ["0.0.0.0/0"]
+      default_network_policy  = true
+      kms_key_arn_access_list = []
+      name_prefix             = "${var.cluster-name}-velero"
+      snapshot_location       = "eu"
+      create_snapshot_class   = true
+    },
+    var.velero
+  )
+
+  values_velero = <<VALUES
+metrics:
+  serviceMonitor:
+    enabled: ${local.kube-prometheus-stack["enabled"] || local.victoria-metrics-k8s-stack["enabled"]}
+configuration:
+  namespace: ${local.velero["namespace"]}
+  features: EnableCSI
+  backupStorageLocation:
+    - name: gcp
+      provider: velero.io/gcp
+      bucket: ${local.velero["bucket"]}
+      default: true
+      config:
+        serviceAccount: ${local.velero["create_iam_account"] ? google_service_account.velero[0].email : "@@SETTHIS@@"}
+  volumeSnapshotLocation:
+    - name: gcp
+      provider: velero.io/gcp
+      snapshotLocation: ${local.velero["snapshot_location"]}
+serviceAccount:
+  server:
+    name: ${local.velero["service_account_name"]}
+    create: true
+    annotations:
+      iam.gke.io/gcp-service-account: ${local.velero["create_iam_account"] ? google_service_account.velero[0].email : ""}
+priorityClassName: ${local.priority-class-ds["create"] ? kubernetes_priority_class.kubernetes_addons_ds[0].metadata[0].name : ""}
+credentials:
+  useSecret: false
+initContainers:
+  - name: velero-plugin-for-gcp
+    image: velero/velero-plugin-for-gcp:v1.10.1
+    imagePullPolicy: IfNotPresent
+    volumeMounts:
+      - mountPath: /target
+        name: plugins
+VALUES
+
+}
+
+resource "google_project_iam_custom_role" "velero" {
+  count       = (local.velero["enabled"] && local.velero["create_iam_account"]) ? 1 : 0
+  role_id     = replace(local.velero["iam_account_name"], "-", "_")
+  title       = "${var.cluster-name} - velero"
+  description = "IAM role used by velero on ${var.cluster-name} to perform backup operations"
+  permissions = [
+    # https://github.com/vmware-tanzu/velero-plugin-for-gcp/blob/main/README.md#create-custom-role-with-permissions-for-the-velero-gsa
+    "compute.disks.get",
+    "compute.disks.create",
+    "compute.disks.createSnapshot",
+    "compute.projects.get",
+    "compute.snapshots.get",
+    "compute.snapshots.create",
+    "compute.snapshots.useReadOnly",
+    "compute.snapshots.delete",
+    "compute.zones.get",
+    # We set these privileges on the bucket directly
+    # "storage.objects.create",
+    # "storage.objects.delete",
+    # "storage.objects.get",
+    # "storage.objects.list",
+    "iam.serviceAccounts.signBlob",
+  ]
+}
+
+resource "google_service_account" "velero" {
+  count        = (local.velero["enabled"] && local.velero["create_iam_account"]) ? 1 : 0
+  account_id   = local.velero["iam_account_name"]
+  display_name = "Velero on GKE ${var.cluster-name}"
+  description  = "Service account for Velero on GKE cluster ${var.cluster-name}"
+}
+
+resource "google_project_iam_member" "velero" {
+  count   = (local.velero["enabled"] && local.velero["create_iam_account"]) ? 1 : 0
+  project = data.google_project.current.project_id
+  role    = google_project_iam_custom_role.velero[0].id
+  member  = google_service_account.velero[0].member
+}
+
+data "google_iam_policy" "velero" {
+  binding {
+    role = "roles/iam.workloadIdentityUser"
+
+    members = [
+      "serviceAccount:${data.google_project.current.project_id}.svc.id.goog[${local.velero["namespace"]}/${local.velero["service_account_name"]}]",
+    ]
+  }
+}
+
+resource "google_service_account_iam_policy" "admin-account-iam" {
+  count              = (local.velero["enabled"] && local.velero["create_iam_account"]) ? 1 : 0
+  service_account_id = google_service_account.velero[0].name
+  policy_data        = data.google_iam_policy.velero.policy_data
+}
+
+module "velero_bucket" {
+  count  = (local.velero["enabled"] && local.velero["create_bucket"]) ? 1 : 0
+  source = "github.com/terraform-google-modules/terraform-google-cloud-storage//modules/simple_bucket?ref=v6.1.0"
+
+  name       = local.velero["name_prefix"]
+  project_id = data.google_project.current.project_id
+
+  versioning = local.velero["bucket_versioning"]
+  location   = local.velero["bucket_location"]
+
+  force_destroy = local.velero["bucket_force_destroy"]
+
+  iam_members = [
+    {
+      role   = "roles/storage.objectUser"
+      member = "serviceAccount:${local.velero["iam_account_name"]}@${data.google_project.current.project_id}.iam.gserviceaccount.com" # This should be google_service_account.velero[0].member, but it's included in a loop so we have to determine it before apply
+    }
+  ]
+  depends_on = [google_service_account.velero]
+}
+
+resource "kubernetes_namespace" "velero" {
+  count = local.velero["enabled"] ? 1 : 0
+
+  metadata {
+    labels = {
+      name = local.velero["namespace"]
+    }
+
+    name = local.velero["namespace"]
+  }
+}
+
+resource "helm_release" "velero" {
+  count                 = local.velero["enabled"] ? 1 : 0
+  repository            = local.velero["repository"]
+  name                  = local.velero["name"]
+  chart                 = local.velero["chart"]
+  version               = local.velero["chart_version"]
+  timeout               = local.velero["timeout"]
+  force_update          = local.velero["force_update"]
+  recreate_pods         = local.velero["recreate_pods"]
+  wait                  = local.velero["wait"]
+  atomic                = local.velero["atomic"]
+  cleanup_on_fail       = local.velero["cleanup_on_fail"]
+  dependency_update     = local.velero["dependency_update"]
+  disable_crd_hooks     = local.velero["disable_crd_hooks"]
+  disable_webhooks      = local.velero["disable_webhooks"]
+  render_subchart_notes = local.velero["render_subchart_notes"]
+  replace               = local.velero["replace"]
+  reset_values          = local.velero["reset_values"]
+  reuse_values          = local.velero["reuse_values"]
+  skip_crds             = local.velero["skip_crds"]
+  verify                = local.velero["verify"]
+  values = compact([
+    local.values_velero,
+    local.velero["extra_values"]
+  ])
+  namespace = kubernetes_namespace.velero.*.metadata.0.name[count.index]
+
+  depends_on = [
+    kubectl_manifest.prometheus-operator_crds
+  ]
+}
+
+resource "kubernetes_network_policy" "velero_default_deny" {
+  count = local.velero["enabled"] && local.velero["default_network_policy"] ? 1 : 0
+
+  metadata {
+    name      = "${kubernetes_namespace.velero.*.metadata.0.name[count.index]}-default-deny"
+    namespace = kubernetes_namespace.velero.*.metadata.0.name[count.index]
+  }
+
+  spec {
+    pod_selector {
+    }
+    policy_types = ["Ingress"]
+  }
+}
+
+resource "kubernetes_network_policy" "velero_allow_namespace" {
+  count = local.velero["enabled"] && local.velero["default_network_policy"] ? 1 : 0
+
+  metadata {
+    name      = "${kubernetes_namespace.velero.*.metadata.0.name[count.index]}-allow-namespace"
+    namespace = kubernetes_namespace.velero.*.metadata.0.name[count.index]
+  }
+
+  spec {
+    pod_selector {
+    }
+
+    ingress {
+      from {
+        namespace_selector {
+          match_labels = {
+            name = kubernetes_namespace.velero.*.metadata.0.name[count.index]
+          }
+        }
+      }
+    }
+
+    policy_types = ["Ingress"]
+  }
+}
+
+resource "kubernetes_network_policy" "velero_allow_monitoring" {
+  count = local.velero["enabled"] && local.velero["default_network_policy"] ? 1 : 0
+
+  metadata {
+    name      = "${kubernetes_namespace.velero.*.metadata.0.name[count.index]}-allow-monitoring"
+    namespace = kubernetes_namespace.velero.*.metadata.0.name[count.index]
+  }
+
+  spec {
+    pod_selector {
+    }
+
+    ingress {
+      ports {
+        port     = "8085"
+        protocol = "TCP"
+      }
+
+      from {
+        namespace_selector {
+          match_labels = {
+            "${local.labels_prefix}/component" = "monitoring"
+          }
+        }
+      }
+    }
+
+    policy_types = ["Ingress"]
+  }
+}
+
+resource "kubernetes_manifest" "velero_snapshot_class" {
+  count = (local.velero["enabled"] && local.velero["create_snapshot_class"]) ? 1 : 0
+  manifest = {
+    apiVersion = "snapshot.storage.k8s.io/v1"
+    kind       = "VolumeSnapshotClass"
+    metadata = {
+      name = "default"
+      labels = {
+        "velero.io/csi-volumesnapshot-class" = "true"
+      }
+    }
+    driver         = "pd.csi.storage.gke.io"
+    deletionPolicy = "Delete"
+  }
+}


### PR DESCRIPTION
# Add support for Velero on GKE clusters

## Description
This PR adds support for Velero deployment on GKE clusters. It creates the needed IAM service account and can add a GCS bucket if needed

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/particuleio/terraform-kubernetes-addons/#doc-generation
