### PR TITLE
enh(renovate): normalize commit messages and show previous version

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -38,6 +38,7 @@
   "reviewers": [
     "team:team"
   ],
+  "commitMessageExtra": "to {{newVersion}} (was {{curentVersion}})",
   "prHourlyLimit": 0,
   "packageRules": [
     {


### PR DESCRIPTION
Currently, whenever a new major version is applied, renovate uses the pretty version which we don't really want

Let's standardize commit messages and show the previous version

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/particuleio/terraform-kubernetes-addons/#doc-generation
