### PR TITLE
fix(cert-manager): switch from installCRDs to crds.enabled

### DIFF
--- a/cert-manager.tf
+++ b/cert-manager.tf
@@ -30,7 +30,8 @@ prometheus:
     enabled: ${local.kube-prometheus-stack["enabled"] || local.victoria-metrics-k8s-stack["enabled"]}
 securityContext:
   fsGroup: 1001
-installCRDs: true
+crds:
+  enabled: true
 VALUES
 
 }

--- a/modules/aws/cert-manager.tf
+++ b/modules/aws/cert-manager.tf
@@ -37,7 +37,8 @@ prometheus:
     enabled: ${local.kube-prometheus-stack["enabled"] || local.victoria-metrics-k8s-stack["enabled"]}
 securityContext:
   fsGroup: 1001
-installCRDs: true
+crds:
+  enabled: true
 VALUES
 
 }

--- a/modules/google/cert-manager.tf
+++ b/modules/google/cert-manager.tf
@@ -48,7 +48,8 @@ prometheus:
     honorLabels: true
 securityContext:
   fsGroup: 1001
-installCRDs: true
+crds:
+  enabled: true
 VALUES
 }
 

--- a/modules/scaleway/cert-manager.tf
+++ b/modules/scaleway/cert-manager.tf
@@ -53,7 +53,8 @@ prometheus:
     enabled: ${local.kube-prometheus-stack["enabled"] || local.victoria-metrics-k8s-stack["enabled"]}
 securityContext:
   fsGroup: 1001
-installCRDs: true
+crds:
+  enabled: true
 VALUES
 
 }


### PR DESCRIPTION
This was introduced in v1.14.0 of the chart, and installCRDs is deprecated now

> WARNING: `installCRDs` is deprecated, use `crds.enabled` instead.

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/particuleio/terraform-kubernetes-addons/#doc-generation

Ref: official docs (look for `installCRDs`) https://artifacthub.io/packages/helm/cert-manager/cert-manager