### PR TITLE
fix: thanos upgrade failing

### DIFF
--- a/modules/aws/thanos.tf
+++ b/modules/aws/thanos.tf
@@ -88,6 +88,8 @@ locals {
       pdb:
         create: true
         minAvailable: 1
+      service:
+        additionalHeadless: true
     VALUES
 
 

--- a/modules/google/thanos.tf
+++ b/modules/google/thanos.tf
@@ -95,6 +95,8 @@ locals {
       pdb:
         create: true
         minAvailable: 1
+      service:
+        additionalHeadless: true
     VALUES
 
   values_thanos_caching = <<-VALUES

--- a/modules/scaleway/thanos.tf
+++ b/modules/scaleway/thanos.tf
@@ -76,6 +76,8 @@ locals {
       pdb:
         create: true
         minAvailable: 1
+      service:
+        additionalHeadless: true
     VALUES
 
 


### PR DESCRIPTION
Due to https://github.com/bitnami/charts/commit/418a890c3210947ff9e1aa9d75ba0fb611681b45 the latest thanos chart upgrade is trying to remove the statefulset's serviceName field which is not an allowed update. Ignore that and create a headless service (even though we don't need it)

> cannot patch "thanos-storegateway" with kind StatefulSet: StatefulSet.apps "thanos-storegateway" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'ordinals', 'template', 'updateStrategy', 'persistentVolumeClaimRetentionPolicy' and 'minReadySeconds' are forbidden

Users who set `receive.enabled` or `ruler.enabled` may need to set `service.additionalHeadless` as well

