### PR TITLE
fix(renovate): correct typo in commit message template

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -38,7 +38,7 @@
   "reviewers": [
     "team:team"
   ],
-  "commitMessageExtra": "to {{newVersion}} (was {{curentVersion}})",
+  "commitMessageExtra": "to {{newVersion}} (was {{currentVersion}})",
   "prHourlyLimit": 0,
   "packageRules": [
     {


### PR DESCRIPTION
# fix(renovate): correct typo in commit message template

## Description

The renovate commit message does not show the previous version correctly, there's a typo in `currentVersion`

Ref: https://docs.renovatebot.com/templates/#exposed-config-options
