### PR TITLE
fix(loki): workaround targetdown alert for loki-gateway

### DIFF
--- a/loki-stack.tf
+++ b/loki-stack.tf
@@ -22,6 +22,10 @@ locals {
 priorityClassName: ${local.priority-class["create"] ? kubernetes_priority_class.kubernetes_addons[0].metadata[0].name : ""}
 serviceMonitor:
   enabled: ${local.kube-prometheus-stack["enabled"] || local.victoria-metrics-k8s-stack["enabled"]}
+gateway:
+  service:
+    labels:
+      prometheus.io/service-monitor: "false"
 VALUES
 }
 

--- a/modules/aws/loki-stack.tf
+++ b/modules/aws/loki-stack.tf
@@ -30,6 +30,10 @@ locals {
       enabled: false
     serviceMonitor:
       enabled: ${local.kube-prometheus-stack["enabled"] || local.victoria-metrics-k8s-stack["enabled"]}
+    gateway:
+      service:
+        labels:
+          prometheus.io/service-monitor: "false"
     priorityClassName: ${local.priority-class["create"] ? kubernetes_priority_class.kubernetes_addons[0].metadata[0].name : ""}
     serviceAccount:
       name: ${local.loki-stack["name"]}

--- a/modules/google/loki-stack.tf
+++ b/modules/google/loki-stack.tf
@@ -32,6 +32,10 @@ locals {
       enabled: false
     serviceMonitor:
       enabled: ${local.kube-prometheus-stack["enabled"] || local.victoria-metrics-k8s-stack["enabled"]}
+    gateway:
+      service:
+        labels:
+          prometheus.io/service-monitor: "false"
     priorityClassName: ${local.priority-class["create"] ? kubernetes_priority_class.kubernetes_addons[0].metadata[0].name : ""}
     serviceAccount:
       create: false

--- a/modules/scaleway/loki-stack.tf
+++ b/modules/scaleway/loki-stack.tf
@@ -26,6 +26,10 @@ locals {
       dnsService: coredns
     serviceMonitor:
       enabled: ${local.kube-prometheus-stack["enabled"] || local.victoria-metrics-k8s-stack["enabled"]}
+    gateway:
+      service:
+        labels:
+          prometheus.io/service-monitor: "false"
     priorityClassName: ${local.priority-class["create"] ? kubernetes_priority_class.kubernetes_addons[0].metadata[0].name : ""}
     persistence:
       enabled: true


### PR DESCRIPTION
# fix(loki-stack): Workaround Prometheus TargetDown alert for loki-gateway component

We wouldn't get much details from nginx anyway as the pod is nginx OSS, so let's forget about metrics for this component

Ref: https://github.com/grafana/loki/issues/9522#issuecomment-2183086539
