### PR TITLE
fix: Add role storage.objectUser to loki-stack (allowing deletion)

### DIFF
--- a/modules/google/README.md
+++ b/modules/google/README.md
@@ -88,7 +88,7 @@ Provides various Kubernetes addons that are often used on Kubernetes with GCP
 | [google_storage_bucket_iam_member.kube_prometheus_stack_thanos_bucket_objectAdmin_iam_permission](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
 | [google_storage_bucket_iam_member.kube_prometheus_stack_thanos_bucket_objectViewer_iam_permission](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
 | [google_storage_bucket_iam_member.loki-stack_gcs_iam_objectCreator_permissions](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
-| [google_storage_bucket_iam_member.loki-stack_gcs_iam_objectViewer_permissions](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
+| [google_storage_bucket_iam_member.loki-stack_gcs_iam_objectUser_permissions](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
 | [google_storage_bucket_iam_member.thanos-receive-receive_gcs_iam_objectViewer_permissions](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
 | [google_storage_bucket_iam_member.thanos-receive_compactor_gcs_iam_legacyBucketWriter_permissions](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
 | [google_storage_bucket_iam_member.thanos-receive_compactor_gcs_iam_objectCreator_permissions](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |

--- a/modules/google/loki-stack.tf
+++ b/modules/google/loki-stack.tf
@@ -188,20 +188,20 @@ module "loki-stack_bucket" {
   }
 }
 
-resource "google_storage_bucket_iam_member" "loki-stack_gcs_iam_objectViewer_permissions" {
+resource "google_storage_bucket_iam_member" "loki-stack_gcs_iam_objectCreator_permissions" {
   count  = local.loki-stack["enabled"] ? 1 : 0
   bucket = local.loki-stack["bucket"]
-  role   = "roles/storage.objectViewer"
+  role   = "roles/storage.objectCreator"
   member = "serviceAccount:${module.iam_assumable_sa_loki-stack[0].gcp_service_account_email}"
   depends_on = [
     module.loki-stack_bucket
   ]
 }
 
-resource "google_storage_bucket_iam_member" "loki-stack_gcs_iam_objectCreator_permissions" {
+resource "google_storage_bucket_iam_member" "loki-stack_gcs_iam_objectUser_permissions" {
   count  = local.loki-stack["enabled"] ? 1 : 0
   bucket = local.loki-stack["bucket"]
-  role   = "roles/storage.objectCreator"
+  role   = "roles/storage.objectUser"
   member = "serviceAccount:${module.iam_assumable_sa_loki-stack[0].gcp_service_account_email}"
   depends_on = [
     module.loki-stack_bucket


### PR DESCRIPTION
# Pull request title

## Description

When loki needs to delete some chunks backed up on the GCS bucket, it fails due to insufficient permission.

The role objectUser is needed. I added it to the module.

I ran the precommit, everything is green.

### Checklist

- [ ] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/particuleio/terraform-kubernetes-addons/#doc-generation
