### PR TITLE
feat(aws)(loki/thanos/velero): allow users to enforce TLS on s3 buckets

### DIFF
--- a/modules/aws/kube-prometheus.tf
+++ b/modules/aws/kube-prometheus.tf
@@ -18,6 +18,7 @@ locals {
       thanos_create_bucket              = true
       thanos_bucket                     = "thanos-store-${var.cluster-name}"
       thanos_bucket_force_destroy       = false
+      thanos_bucket_enforce_tls         = false
       thanos_store_config               = null
       thanos_version                    = "v0.37.2"
       enabled                           = false
@@ -417,6 +418,8 @@ module "kube-prometheus-stack_thanos_bucket" {
     target_bucket = local.s3-logging.create_bucket ? module.s3_logging_bucket.s3_bucket_id : local.s3-logging.custom_bucket_id
     target_prefix = "${var.cluster-name}/${local.kube-prometheus-stack.name}/"
   } : {}
+
+  attach_deny_insecure_transport_policy = local.kube-prometheus-stack["thanos_bucket_enforce_tls"]
 
   tags = local.tags
 }

--- a/modules/aws/loki-stack.tf
+++ b/modules/aws/loki-stack.tf
@@ -16,6 +16,7 @@ locals {
       bucket                    = "loki-store-${var.cluster-name}"
       bucket_lifecycle_rule     = []
       bucket_force_destroy      = false
+      bucket_enforce_tls        = false
       generate_ca               = true
       trusted_ca_content        = null
       create_promtail_cert      = true
@@ -205,6 +206,8 @@ module "loki_bucket" {
     target_bucket = local.s3-logging.create_bucket ? module.s3_logging_bucket.s3_bucket_id : local.s3-logging.custom_bucket_id
     target_prefix = "${var.cluster-name}/${local.loki-stack.name}/"
   } : {}
+
+  attach_deny_insecure_transport_policy = local.loki-stack["bucket_enforce_tls"]
 
   tags = local.tags
 

--- a/modules/aws/thanos.tf
+++ b/modules/aws/thanos.tf
@@ -18,6 +18,7 @@ locals {
       create_bucket             = false
       bucket                    = "thanos-store-${var.cluster-name}"
       bucket_force_destroy      = false
+      bucket_enforce_tls        = false
       generate_ca               = false
       trusted_ca_content        = null
       name_prefix               = "${var.cluster-name}-thanos"
@@ -293,6 +294,8 @@ module "thanos_bucket" {
     target_bucket = local.s3-logging.create_bucket ? module.s3_logging_bucket.s3_bucket_id : local.s3-logging.custom_bucket_id
     target_prefix = "${var.cluster-name}/${local.thanos.name}/"
   } : {}
+
+  attach_deny_insecure_transport_policy = local.thanos["bucket_enforce_tls"]
 
   tags = local.tags
 }

--- a/modules/aws/velero.tf
+++ b/modules/aws/velero.tf
@@ -14,6 +14,7 @@ locals {
       create_bucket             = true
       bucket                    = "${var.cluster-name}-velero"
       bucket_force_destroy      = false
+      bucket_enforce_tls        = false
       allowed_cidrs             = ["0.0.0.0/0"]
       default_network_policy    = true
       kms_key_arn_access_list   = []
@@ -185,6 +186,8 @@ module "velero_thanos_bucket" {
     target_bucket = local.s3-logging.create_bucket ? module.s3_logging_bucket.s3_bucket_id : local.s3-logging.custom_bucket_id
     target_prefix = "${var.cluster-name}/${local.velero.name}/"
   } : {}
+
+  attach_deny_insecure_transport_policy = local.velero.bucket_enforce_tls
 
   tags = local.tags
 }


### PR DESCRIPTION
# allow users to enforce TLS on s3 buckets

## Description

This PR adds a flag to allow users to enforce TLS on supporting s3 buckets for the following addons:
- kube-prometheus-stack
- loki-stack
- thanos
- velero

The default value has been set to `false` in order to preserve the current behaviour.

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/particuleio/terraform-kubernetes-addons/#doc-generation
