### PR TITLE
fix(thanos): fix comparison for bucket creation

### DIFF
--- a/modules/google/thanos.tf
+++ b/modules/google/thanos.tf
@@ -29,7 +29,7 @@ locals {
 
   thanos_bucket = (
     local.thanos["enabled"] && local.kube-prometheus-stack["enabled"] && local.kube-prometheus-stack["thanos_create_bucket"] ? module.kube-prometheus-stack_kube-prometheus-stack_bucket[0].name :
-    local.thanos["enabled"] && local.thanos["create_bucket"] ? module.thanos_bucket[0] : local.thanos["bucket"]
+    local.thanos["enabled"] && local.thanos["create_bucket"] ? module.thanos_bucket[0].name : local.thanos["bucket"]
   )
 
   values_thanos = <<-VALUES


### PR DESCRIPTION
# Pull request title

## Description

fix this error:
```
│ Error: Inconsistent conditional result types
│
│   on thanos.tf line 32, in locals:
│   32:     local.thanos["enabled"] && local.thanos["create_bucket"] ? module.thanos_bucket[0] : local.thanos["bucket"]
│     ├────────────────
│     │ local.thanos["bucket"] is "thanos-store-kiln-gcp-telemetry-europe-west1"
│     │ local.thanos["create_bucket"] is "true"
│     │ local.thanos["enabled"] is true
│     │ module.thanos_bucket[0] is object with 4 attributes
│
│ The true and false result expressions must have consistent types. The 'true' value is object, but the 'false' value is string.
```

left hand of the ternary shall return the bucket name, not the full bucket

Please explain the changes you made here and link to any relevant issues.

### Checklist

- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/particuleio/terraform-kubernetes-addons/#doc-generation
