### PR TITLE
fix: update node-problem-detector chart repository

### DIFF
--- a/helm-dependencies.yaml
+++ b/helm-dependencies.yaml
@@ -84,8 +84,8 @@ dependencies:
     version: 3.13.0
     repository: https://kubernetes-sigs.github.io/metrics-server/
   - name: node-problem-detector
-    version: 2.3.14
-    repository: https://charts.deliveryhero.io/
+    version: 2.4.0
+    repository: oci://ghcr.io/deliveryhero/helm-charts
   - name: prometheus-adapter
     version: 5.3.0
     repository: https://prometheus-community.github.io/helm-charts


### PR DESCRIPTION
# fix: update node-problem-detector chart repository

## Description

The node-problem-detector Chart migrated to github package registry https://github.com/deliveryhero/helm-charts/tree/master/stable/node-problem-detector

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/particuleio/terraform-kubernetes-addons/#doc-generation
